### PR TITLE
尝试修复在部分场景下开启`锁屏底部显示充电信息`时导致系统界面闪退

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/lockscreen/ChargingCVP.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/lockscreen/ChargingCVP.kt
@@ -115,7 +115,7 @@ object ChargingCVP : BaseHook() {
                                         invokeMethodBestMatch(mBatteryStatus, "isPluggedIn")
                                     val mContext =
                                         getObjectOrNull(instanceMiuiChargeController, "mContext")
-                                    val clazzChargeUtils = loadClass("com.miui.charge.ChargeUtils")
+                                    val clazzChargeUtils = loadClass("com.miui.charge.ChargeUtils", lpparam.classLoader)
                                     val chargingHintText =
                                         invokeStaticMethodBestMatch(
                                             clazzChargeUtils,


### PR DESCRIPTION
相关 issue: 
* https://github.com/GSWXXN/RestoreSplashScreen/issues/34 
* https://github.com/Xposed-Modules-Repo/com.gswxxn.restoresplashscreen/issues/3#issuecomment-1837319082 
* https://github.com/ReChronoRain/HyperCeiler/issues/136

前两个问题是同时使用 [MIUI 遮罩进化](https://github.com/GSWXXN/RestoreSplashScreen) 和开启`锁屏底部显示充电信息`时产生的, 我在调试的时候发现 [HyperCeiler](https://github.com/ReChronoRain/HyperCeiler) 传给 [EzXHelper](https://github.com/KyuubiRan/EzXHelper) 的 ClassLoader 是 `系统桌面` 的 ClassLoader (通过在 pr 的位置捕捉异常并输出 `EzXHelper.hostPackageName` 可以发现这个问题), 在我的测试中指定了正确的 ClassLoader 后就没有问题了.

https://github.com/GSWXXN/RestoreSplashScreen/blob/fd0df958d367a4e50781859893b029ec1e537c3b/app/src/main/java/com/gswxxn/restoresplashscreen/utils/MIUIIconsHelper.kt#L27-L30

可能是我在遮罩模块中使用了 `系统桌面` 的 Context (可以看下上面的代码片段链接), 导致 EzXHelper 获取了 `系统桌面` 的 ClassLoader, 但还是好奇怪啊 :-(

虽然上面提到的最后一个 Issue 并没有使用 MIUI 遮罩进化, 但产生问题的原因应该差不多?

问题修复起来比较简单, 但定位问题还是花了我一点时间的, 详细描述一下也是为以后出现类似问题提供一个参考