### PR TITLE
修复小米10S上同时操作torch和flashlight节点后会导致相机内闪光灯无法打开的问题

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/controlcenter/FlashLight.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/controlcenter/FlashLight.java
@@ -1,6 +1,6 @@
 /*
   * This file is part of HyperCeiler.
-  
+
   * HyperCeiler is free software: you can redistribute it and/or modify
   * it under the terms of the GNU Affero General Public License as
   * published by the Free Software Foundation, either version 3 of the
@@ -310,11 +310,12 @@ public class FlashLight extends TileUtils {
             File file2 = new File(flashFileSwitch);
             File file3 = new File(flashFileOther);
             if (file1.exists() && file2.exists()) {
-                writeFileModule(flashFileTorch, 0);
-                writeFileModule(flashFileTorch, flashInt);
                 if (file3.exists()) {
                     writeFileModule(flashFileOther, 0);
                     writeFileModule(flashFileOther, flashInt);
+                } else {
+                    writeFileModule(flashFileTorch, 0);
+                    writeFileModule(flashFileTorch, flashInt);
                 }
             }
             else if (file1.exists()) {


### PR DESCRIPTION
小米10S上如果同时操作torch和flashlight节点，会导致闪光灯亮度调整后，再进入相机，无法在相机内正常打开闪光灯，只能重启手机解决。