### PR TITLE
修复鲁班V6.0.5及以下版本需要打开后返回再打开一次才能进入的问题

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/mtb/BypassAuthentication.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/mtb/BypassAuthentication.kt
@@ -1,6 +1,6 @@
 /*
   * This file is part of HyperCeiler.
-  
+
   * HyperCeiler is free software: you can redistribute it and/or modify
   * it under the terms of the GNU Affero General Public License as
   * published by the Free Software Foundation, either version 3 of the
@@ -27,6 +27,16 @@ import com.sevtinge.hyperceiler.utils.setObjectField
 object BypassAuthentication : BaseHook() {
     override fun init() {
         val mModemTestBoxClass = loadClass("com.xiaomi.mtb.activity.ModemTestBoxMainActivity")
+
+        runCatching {
+            loadClass("com.xiaomi.mtb.XiaoMiServerPermissionCheck").methodFinder().first {
+                name == "updatePermissionClass"
+            }.createHook {
+                after {
+                    it.result = 0L
+                }
+            }
+        }
 
         runCatching {
             loadClass("com.xiaomi.mtb.MtbApp").methodFinder().first {


### PR DESCRIPTION
(onCreate->onPause->onResume才能打开并不提示鉴权)