### PR TITLE
Fix ic_hyperceiler_settings size

### DIFF
--- a/app/src/main/res/drawable/ic_hyperceiler_settings_v140.xml
+++ b/app/src/main/res/drawable/ic_hyperceiler_settings_v140.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="30dp"
-    android:height="30dp"
+    android:width="28dp"
+    android:height="28dp"
     android:viewportWidth="270"
     android:viewportHeight="270">
     <path


### PR DESCRIPTION
修改圆角矩形的设置图标尺寸，使其与设置中其他图标尺寸一致