### PR TITLE
跳过开启SIM卡安全保护时需要系统登录小米账号的验证功能

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SecurityCenter.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SecurityCenter.java
@@ -54,6 +54,7 @@ import com.sevtinge.hyperceiler.module.hook.securitycenter.beauty.BeautyPrivacy;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.lab.AiClipboardEnable;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.lab.BlurLocationEnable;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.lab.GetNumberEnable;
+import com.sevtinge.hyperceiler.module.hook.securitycenter.other.BypassSimLockMiAccountAuth;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.DisableRootCheck;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.FuckRiskPkg;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints;
@@ -112,6 +113,7 @@ public class SecurityCenter extends BaseModule {
         initHook(FuckRiskPkg.INSTANCE, mPrefsMap.getBoolean("security_center_disable_send_malicious_app_notification"));
         initHook(NoLowBatteryWarning.INSTANCE, mPrefsMap.getBoolean("security_center_remove_low_battery_reminder"));
         initHook(new UnlockFbo(), mPrefsMap.getBoolean("security_center_unlock_fbo"));
+        initHook(BypassSimLockMiAccountAuth.INSTANCE, mPrefsMap.getBoolean("security_center_bypass_simlock_miaccount_auth"));
 
         // 小窗和气泡通知
         initHook(new RemoveConversationBubbleSettingsRestriction(), mPrefsMap.getBoolean("security_center_remove_conversation_bubble_settings_restriction"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/securitycenter/other/BypassSimLockMiAccountAuth.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/securitycenter/other/BypassSimLockMiAccountAuth.kt
@@ -1,0 +1,36 @@
+/*
+  * This file is part of HyperCeiler.
+
+  * HyperCeiler is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as
+  * published by the Free Software Foundation, either version 3 of the
+  * License.
+
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Affero General Public License for more details.
+
+  * You should have received a copy of the GNU Affero General Public License
+  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+  * Copyright (C) 2023-2024 HyperCeiler Contributions
+*/
+package com.sevtinge.hyperceiler.module.hook.securitycenter.other
+
+import com.github.kyuubiran.ezxhelper.*
+import com.github.kyuubiran.ezxhelper.HookFactory.`-Static`.createHook
+import com.github.kyuubiran.ezxhelper.finders.MethodFinder.`-Static`.methodFinder
+import com.sevtinge.hyperceiler.module.base.*
+
+object BypassSimLockMiAccountAuth : BaseHook() {
+    override fun init() {
+        runCatching {
+            ClassUtils.loadClass("com.miui.simlock.b").methodFinder()
+                .filterByName("m")
+                .single().createHook {
+                    returnConstant(true)
+                }
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1438,6 +1438,8 @@
     <string name="security_center_sidebar_function_title">全局侧边栏功能</string>
     <string name="security_center_game_speed">快速启动游戏</string>
     <string name="security_center_game_speed_desc">在启动游戏时倍速通过开屏动画，仅部分游戏支持</string>
+    <string name="security_center_bypass_simlock_miaccount_auth">SIM卡安全保护跳过登录验证</string>
+    <string name="security_center_bypass_simlock_miaccount_auth_desc">开启SIM卡安全保护功能时无需登录小米账号</string>
     <string name="security_center_aosp_app_info">添加 \"原生应用信息\" 入口</string>
     <string name="security_center_aosp_app_info_label">原生应用信息</string>
     <string name="security_center_aosp_app_manager">添加 \"原生应用管理\" 入口</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1404,6 +1404,8 @@
     <string name="security_center_sidebar_function_title">Sidebar Function</string>
     <string name="security_center_game_speed">Launch the game quickly</string>
     <string name="security_center_game_speed_desc">When launching the game, it passes the opening screen animation at 3x speed, which is only supported by some games</string>
+    <string name="security_center_bypass_simlock_miaccount_auth">SIM security no Account needed</string>
+    <string name="security_center_bypass_simlock_miaccount_auth_desc">Bypass SIM security Mi Account needed, you can open this function even without logging in XiaoMi Account</string>
     <string name="security_center_aosp_app_info_label">AOSP App Info</string>
     <string name="security_center_aosp_app_info">Add AOSP App Info entry</string>
     <string name="security_center_aosp_app_manager_label">AOSP App Manager</string>

--- a/app/src/main/res/xml/security_center.xml
+++ b/app/src/main/res/xml/security_center.xml
@@ -284,6 +284,12 @@
             android:title="@string/security_center_game_speed"
             app:isPreferenceVisible="false" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_security_center_bypass_simlock_miaccount_auth"
+            android:summary="@string/security_center_bypass_simlock_miaccount_auth_desc"
+            android:title="@string/security_center_bypass_simlock_miaccount_auth" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
跳过开启SIM卡安全保护时需要系统登录小米账号的验证功能