### PR TITLE
<Fix>网速单排显示，会四倍网速

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/statusbar/network/news/NewNetworkSpeed.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/statusbar/network/news/NewNetworkSpeed.kt
@@ -203,7 +203,7 @@ object NewNetworkSpeed : BaseHook() {
                         }
                     // 计算总网速
                     val ax =
-                        humanReadableByteCount(mContext, newTxBytesFixed + newRxBytesFixed)
+                        humanReadableByteCount(mContext, txSpeed + rxSpeed)
                     // 存储是否隐藏慢速的条件的结果
                     val isLowSpeed = hideLow && (txSpeed + rxSpeed) < lowLevel
                     val isAllLowSpeed =


### PR DESCRIPTION
#469 

我也不知道为什么用 `new*xBytesFixed`，但是改成和前面一样的变量 `*xSpeed` 后就正常了，可能是以前为了兼容性考虑做的新变量。
所以正确性和稳定性未知，merge前还是先测试以下为好。