### PR TITLE
<Add>系统更新关闭“开启自动更新”提示

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/Updater.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/Updater.java
@@ -42,6 +42,6 @@ public class Updater extends BaseModule {
             initHook(DeviceModify.INSTANCE, !TextUtils.isEmpty(mPrefsMap.getString("updater_device", "")));
         }
         initHook(new VabUpdate(), mPrefsMap.getBoolean("updater_fuck_vab"));
-        initHook(new AutoUpdateDialog(), mPrefsMap.getBoolean("auto_update_dialog"));
+        initHook(AutoUpdateDialog.INSTANCE, mPrefsMap.getBoolean("updater_diable_dialog"));
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/Updater.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/Updater.java
@@ -42,6 +42,6 @@ public class Updater extends BaseModule {
             initHook(DeviceModify.INSTANCE, !TextUtils.isEmpty(mPrefsMap.getString("updater_device", "")));
         }
         initHook(new VabUpdate(), mPrefsMap.getBoolean("updater_fuck_vab"));
-        initHook(new AutoUpdateDialog());
+        initHook(new AutoUpdateDialog(), mPrefsMap.getBoolean("auto_update_dialog"));
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/Updater.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/Updater.java
@@ -22,6 +22,7 @@ import android.text.TextUtils;
 
 import com.sevtinge.hyperceiler.module.base.BaseModule;
 import com.sevtinge.hyperceiler.module.hook.updater.AndroidVersionCode;
+import com.sevtinge.hyperceiler.module.hook.updater.AutoUpdateDialog;
 import com.sevtinge.hyperceiler.module.hook.updater.DeviceModify;
 import com.sevtinge.hyperceiler.module.hook.updater.VabUpdate;
 import com.sevtinge.hyperceiler.module.hook.updater.VersionCodeModify;
@@ -41,5 +42,6 @@ public class Updater extends BaseModule {
             initHook(DeviceModify.INSTANCE, !TextUtils.isEmpty(mPrefsMap.getString("updater_device", "")));
         }
         initHook(new VabUpdate(), mPrefsMap.getBoolean("updater_fuck_vab"));
+        initHook(new AutoUpdateDialog());
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
@@ -1,20 +1,42 @@
 package com.sevtinge.hyperceiler.module.hook.updater
 
+import com.github.kyuubiran.ezxhelper.*
 import com.sevtinge.hyperceiler.module.base.BaseHook
+import de.robv.android.xposed.XposedBridge.*
 
 class AutoUpdateDialog : BaseHook() {
     override fun init() {
-        //TODO 不写死程序
-        findAndHookMethod(
-            "com.android.updater.i1",
-            "Z2",
-            Boolean::class.java,
-            Boolean::class.java,
-            object : replaceHookedMethod() {
-                override fun replace(param: MethodHookParam?): Any {
-                    return 0
+        // TODO 不写死程序
+        try {
+            findAndHookMethod(
+                "com.android.updater.i1",
+                "Z2",
+                Boolean::class.java,
+                Boolean::class.java,
+                object : replaceHookedMethod() {
+                    override fun replace(param: MethodHookParam?): Any {
+                        return 0
+                    }
                 }
-            }
-        )
+            )
+        } catch (e: Exception) {
+            log(e)
+        }
+
+        try {
+            findAndHookMethod(
+                "com.android.updater.i1",
+                "q3",
+                Long::class.java,
+                Int::class.java,
+                object : replaceHookedMethod() {
+                    override fun replace(param: MethodHookParam?): Any {
+                        return 0
+                    }
+                }
+            )
+        } catch (e: Exception) {
+            log(e)
+        }
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
@@ -2,41 +2,39 @@ package com.sevtinge.hyperceiler.module.hook.updater
 
 import com.github.kyuubiran.ezxhelper.*
 import com.sevtinge.hyperceiler.module.base.BaseHook
+import com.sevtinge.hyperceiler.module.base.dexkit.DexKit.dexKitBridge
+import com.sevtinge.hyperceiler.utils.*
 import de.robv.android.xposed.XposedBridge.*
+import org.luckypray.dexkit.query.enums.*
 
-class AutoUpdateDialog : BaseHook() {
+object AutoUpdateDialog : BaseHook() {
+    private val find1 by lazy {
+        dexKitBridge.findMethod {
+            matcher {
+                addCall {
+                    addUsingString("isShowAutoSetDialog", StringMatchType.Contains)
+                }
+                paramTypes("boolean", "boolean")
+            }
+        }.single().getMethodInstance(EzXHelper.safeClassLoader)
+    }
+
+    private val find2 by lazy {
+        dexKitBridge.findMethod {
+            matcher {
+                addCall {
+                    addUsingString("isShowMobileDownloadDialog", StringMatchType.Contains)
+                }
+                paramTypes("long", "int")
+            }
+        }.single().getMethodInstance(EzXHelper.safeClassLoader)
+    }
+
     override fun init() {
-        // TODO 不写死程序
-        try {
-            findAndHookMethod(
-                "com.android.updater.i1",
-                "Z2",
-                Boolean::class.java,
-                Boolean::class.java,
-                object : replaceHookedMethod() {
-                    override fun replace(param: MethodHookParam?): Any {
-                        return 0
-                    }
-                }
-            )
-        } catch (e: Exception) {
-            log(e)
-        }
-
-        try {
-            findAndHookMethod(
-                "com.android.updater.i1",
-                "q3",
-                Long::class.java,
-                Int::class.java,
-                object : replaceHookedMethod() {
-                    override fun replace(param: MethodHookParam?): Any {
-                        return 0
-                    }
-                }
-            )
-        } catch (e: Exception) {
-            log(e)
+        logD(TAG, lpparam.packageName, "get find1 is $find1")
+        logD(TAG, lpparam.packageName, "get find2 is $find2")
+        setOf(find1, find2).forEach {
+            it.replaceMethod { 0 }
         }
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
@@ -1,0 +1,21 @@
+package com.sevtinge.hyperceiler.module.hook.updater
+
+import com.sevtinge.hyperceiler.module.base.BaseHook
+
+class AutoUpdateDialog : BaseHook() {
+    override fun init() {
+        println("*AUD")
+        findAndHookMethod(
+            "com.android.updater.i1",
+            "Z2",
+            Boolean::class.java,
+            Boolean::class.java,
+            object : replaceHookedMethod() {
+                override fun replace(param: MethodHookParam?): Any {
+                    println("asd")
+                    return 0
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/updater/AutoUpdateDialog.kt
@@ -4,7 +4,7 @@ import com.sevtinge.hyperceiler.module.base.BaseHook
 
 class AutoUpdateDialog : BaseHook() {
     override fun init() {
-        println("*AUD")
+        //TODO 不写死程序
         findAndHookMethod(
             "com.android.updater.i1",
             "Z2",
@@ -12,7 +12,6 @@ class AutoUpdateDialog : BaseHook() {
             Boolean::class.java,
             object : replaceHookedMethod() {
                 override fun replace(param: MethodHookParam?): Any {
-                    println("asd")
                     return 0
                 }
             }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -971,6 +971,7 @@
     <string name="updater_miui_version_desc">仅对系统更新修改，可在一定程度上屏蔽系统更新</string>
     <string name="updater_device">伪装机型</string>
     <string name="updater_device_desc">输入目标设备的机型代号以指定机型，可用于获取其他机型的 ROM 包，该功能极度危险</string>
+    <string name="updater_diable_dialog">移除 “开启自动更新” 弹窗</string>
     <!--权限管理服务-->
     <string name="lbe">权限管理服务</string>
     <string name="clipboard">剪切板</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -895,6 +895,7 @@
     <string name="updater_miui_version_desc">僅對系统更新修改，可在一定程度上遮罩系统更新</string>
     <string name="updater_device">偽裝機型</string>
     <string name="updater_device_desc">輸入目標設備代號以指定設備，可用於獲取其他機型的 ROM 包，此功能極度危險</string>
+    <string name="updater_diable_dialog">移除 “開啟自動更新” 對話框</string>
     <!--Permissions-->
     <string name="lbe">權限管理服務</string>
     <string name="clipboard">剪貼簿</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -895,6 +895,7 @@
     <string name="updater_miui_version_desc">僅對系統更新修改，可在一定程度上遮罩系統更新</string>
     <string name="updater_device">偽裝機型</string>
     <string name="updater_device_desc">輸入目標機型代號以指定機型，可用於獲取其他機型的 ROM 包，此功能極度危險</string>
+    <string name="updater_diable_dialog">移除 “開啟自動更新” 對話框</string>
     <!--Permissions-->
     <string name="lbe">權限管理服務</string>
     <string name="clipboard">剪貼簿</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -947,6 +947,7 @@
     <string name="updater_miui_version_desc">Only modify the system update, which can shield the system update to a certain extent</string>
     <string name="updater_device">Fake device for Updater</string>
     <string name="updater_device_desc">Enter the model code of the target device to specify the model, which can be used to obtain ROM packages for other models, which is extremely dangerous</string>
+    <string name="updater_diable_dialog">Disable pop-up of \"Turn on automatic updates\" dialog</string>
     <!--Permissions-->
     <string name="lbe">Permissions</string>
     <string name="clipboard">Clipboard</string>
@@ -1647,5 +1648,4 @@
     <string name="tip_default">Tip: Here is the default tip. If you can see me, it means that there is a problem with HyperCeiler, please report it to the developer in a timely and effective manner.</string>
 
     <string name="preference_recommend_tip">Looking for something else?</string>
-    <string name="auto_update_dialog">Disalbe auto update dialog</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1647,4 +1647,5 @@
     <string name="tip_default">Tip: Here is the default tip. If you can see me, it means that there is a problem with HyperCeiler, please report it to the developer in a timely and effective manner.</string>
 
     <string name="preference_recommend_tip">Looking for something else?</string>
+    <string name="auto_update_dialog">Disalbe auto update dialog</string>
 </resources>

--- a/app/src/main/res/xml/updater.xml
+++ b/app/src/main/res/xml/updater.xml
@@ -48,4 +48,8 @@
         android:key="prefs_key_updater_device"
         app:isPreferenceVisible="true" />
 
+    <SwitchPreference
+        android:title="@string/auto_update_dialog"
+        android:key="prefs_key_auto_update_dialog"
+        android:defaultValue="false" />
 </PreferenceScreen>

--- a/app/src/main/res/xml/updater.xml
+++ b/app/src/main/res/xml/updater.xml
@@ -10,6 +10,11 @@
         android:defaultValue="false" />
 
     <SwitchPreference
+        android:title="@string/updater_diable_dialog"
+        android:key="prefs_key_updater_diable_dialog"
+        android:defaultValue="false" />
+
+    <SwitchPreference
         android:title="@string/updater_enable_miui_version"
         android:key="prefs_key_updater_enable_miui_version"
         android:defaultValue="false" />
@@ -47,9 +52,4 @@
         android:summary="@string/updater_device_desc"
         android:key="prefs_key_updater_device"
         app:isPreferenceVisible="true" />
-
-    <SwitchPreference
-        android:title="@string/auto_update_dialog"
-        android:key="prefs_key_auto_update_dialog"
-        android:defaultValue="false" />
 </PreferenceScreen>


### PR DESCRIPTION
# <Add>系统更新关闭“开启自动更新”提示
#477 

## 必要性
有人认为屏蔽系统更新可阻止该提示，但是直接屏蔽系统更新会带来许多问题，比如说无法更新新版本。当我们任然需要更新新版本时，还是会遇到该提示。但是开启自动更新会带来更大的问题，比如说掉root；不开启又会弹窗烦人。所以我认为该功能是非常有必要的。

## 测试
经过我的测试没问题。其他设备未知

## TODO
1. 硬编码 hook 点，以后更新可能有问题
2. 没写开关的 `summery`

## info
系统更新版本 8.4.7。目前已为最新版