### PR TITLE
在引导式访问中禁用快捷窗口按钮三个点

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/UiLockApp.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/UiLockApp.java
@@ -70,10 +70,12 @@ public class UiLockApp extends BaseHook {
                                 isLock = getLockApp(context) != -1;
                                 if (getLockApp(context) != -1) {
                                     try {
-                                        XposedHelpers.callMethod(param.thisObject, "scheduleAutoHide");
+                                        //XposedHelpers.callMethod(param.thisObject, "scheduleAutoHide");
                                     } catch (Exception e) {
 
                                     }
+                                }else {//退出时引发崩溃以恢复底栏
+                                    XposedHelpers.callMethod(param.thisObject, "scheduleAutoHide");
                                 }
                             }
                         };

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/UiLockApp.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/UiLockApp.java
@@ -56,6 +56,8 @@ public class UiLockApp extends BaseHook {
     public int eCount = 0;
     boolean isLock = false;
 
+    boolean isObserver2 = false;
+
     @Override
     public void init() throws NoSuchMethodException {
         hookAllConstructors("com.android.systemui.statusbar.phone.AutoHideController",
@@ -182,6 +184,18 @@ public class UiLockApp extends BaseHook {
                     if (getLockApp(mContext) == taskId && lockId != -1) {
                         param.setResult(true);
                     }
+                }
+            }
+        );
+
+        findAndHookMethod("com.android.wm.shell.miuimultiwinswitch.miuiwindowdecor.MiuiBaseWindowDecoration",
+            "shouldHideCaption",
+            new MethodHook() {
+                @Override
+                protected void after(MethodHookParam param) {
+                    Context context = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
+                    isLock = getLockApp(context) != -1;
+                    param.setResult(isLock);
                 }
             }
         );


### PR DESCRIPTION
在引导式访问中使用快捷窗口按钮没有任何实际意义、只会导致ui错乱，显然应该禁用
（另外这也是解决引导式访问中各种干扰的一环（有关我即将提交的另个pull request））

另外这里为确保功能正常，绕过（而非修复）了一个已经存在的bug，有关 #406 ，我延后了systemui crash的时机