### PR TITLE
fix:修复退出引导式访问后可能出现的底部手势失效

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/SystemLockApp.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/SystemLockApp.java
@@ -61,7 +61,7 @@ public class SystemLockApp extends BaseHook {
                                             taskId = getLockApp(context);
                                             XposedHelpers.callMethod(param.thisObject, "startSystemLockTaskMode", taskId);
                                         } else {
-                                            XposedHelpers.callMethod(param.thisObject, "stopSystemLockTaskMode");
+                                            new Handler(context.getMainLooper()).postDelayed(() -> XposedHelpers.callMethod(param.thisObject, "stopSystemLockTaskMode"),300);
                                         }
                                     }
                                 };


### PR DESCRIPTION
在部分设备（尤其是Pad上），退出引导式访问后底部手势会失效
经测试发现，发生问题的原因是在hide_gesture_line引发的底部手势线恢复成功前就进行了stopSystemLockTaskMode，相当于先退出引导式访问再恢复手势线，此时手势线功能失效，而先恢复手势线再退出引导式访问则正常。
此PR通过延迟推出引导式访问以等待底部手势线恢复