### PR TITLE
修复安全方法无法捕捉错误

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/base/tool/HookTool.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/base/tool/HookTool.java
@@ -169,7 +169,7 @@ public class HookTool extends XposedTool {
     public void safeFindAndHookMethod(String className, String methodName, Object... parameterTypesAndCallback) {
         try {
             findAndHookMethod(className, methodName, parameterTypesAndCallback);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logE(TAG, "safeHook: " + e);
         }
     }


### PR DESCRIPTION
修复无法捕获xposed抛出的NoSuchMethodError，周围的代码也都是Throwable