### PR TITLE
修复引导式访问的解除固定时跳转锁屏不生效

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/SystemLockApp.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/SystemLockApp.java
@@ -40,7 +40,6 @@ public class SystemLockApp extends BaseHook {
     private int taskId;
     private boolean isObserver = false;
     boolean isLock = false;
-    boolean needLockScreen = false;
 
     @Override
     public void init() throws NoSuchMethodException {
@@ -63,21 +62,12 @@ public class SystemLockApp extends BaseHook {
                                         } else {
                                             new Handler(context.getMainLooper()).postDelayed(() -> XposedHelpers.callMethod(param.thisObject, "stopSystemLockTaskMode"),300);
                                         }
+
                                     }
                                 };
                                 context.getContentResolver().registerContentObserver(
                                         Settings.Global.getUriFor("key_lock_app"),
                                         false, contentObserver);
-
-                                ContentObserver contentObserver1 = new ContentObserver(new Handler(context.getMainLooper())) {
-                                    @Override
-                                    public void onChange(boolean selfChange) {
-                                        needLockScreen = getMyLockScreen(context) == 1;
-                                    }
-                                };
-                                context.getContentResolver().registerContentObserver(
-                                        Settings.Global.getUriFor("exit_lock_app_screen"),
-                                        false, contentObserver1);
                                 isObserver = true;
                             }
                         } catch (Throwable e) {
@@ -112,7 +102,8 @@ public class SystemLockApp extends BaseHook {
                 new MethodHook() {
                     @Override
                     protected void before(MethodHookParam param) {
-                        if (needLockScreen) {
+                        Context context = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
+                        if (getMyLockScreen(context) == 1) {
                             param.setResult(true);
                         } else {
                             param.setResult(false);

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/UiLockApp.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/UiLockApp.java
@@ -86,6 +86,11 @@ public class UiLockApp extends BaseHook {
                                     false, contentObserver);
                             isListen = true;
                         }
+                        if (mPrefsMap.getBoolean("system_framework_guided_access_screen")) {
+                            setMyLockScreen(mContext, 1);
+                        } else {
+                            setMyLockScreen(mContext, 0);
+                        }
                     }
                 }
         );


### PR DESCRIPTION
修复引导式访问的解除固定时锁屏功能在日常使用时不生效。bug可能原因：SystemLockApp设置的相关监听没有机会捕捉exit_lock_app_screen值变化，因为它没变
另外此修复可能使原本的立即生效最晚延后为重启后生效（因为原来在修改设置后才会导致值变化，进而被捕捉以设置正确的needLockScreen）