### PR TITLE
修复引导式访问解除固定时锁屏不生效

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/SystemLockApp.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/SystemLockApp.java
@@ -78,6 +78,8 @@ public class SystemLockApp extends BaseHook {
                                 context.getContentResolver().registerContentObserver(
                                         Settings.Global.getUriFor("exit_lock_app_screen"),
                                         false, contentObserver1);
+                                needLockScreen = getMyLockScreen(context) == 1;
+
                                 isObserver = true;
                             }
                         } catch (Throwable e) {


### PR DESCRIPTION
修复引导式访问的解除固定时锁屏功能在日常使用时不生效。bug可能原因：SystemLockApp设置的相关监听没有机会捕捉exit_lock_app_screen值变化，因为它没变