### PR TITLE
允许直接拨打类似**21*8#的MMI码来开启呼叫转移

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/Telecom.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/Telecom.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2024 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.module.app;
+
+import com.sevtinge.hyperceiler.module.base.BaseModule;
+import com.sevtinge.hyperceiler.module.base.HookExpand;
+import com.sevtinge.hyperceiler.module.hook.telecom.ScamReminderBypass;
+
+@HookExpand(pkg = "com.android.server.telecom", isPad = false, tarAndroid = 33)
+public class Telecom extends BaseModule {
+    @Override
+    public void handleLoadPackage() {
+        initHook(new ScamReminderBypass(), mPrefsMap.getBoolean("scam_reminder_bypass"));
+    }
+}

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/telecom/ScamReminderBypass.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/telecom/ScamReminderBypass.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2024 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.module.hook.telecom;
+
+import com.sevtinge.hyperceiler.module.base.BaseHook;
+
+public class ScamReminderBypass extends BaseHook {
+    @Override
+    public void init() throws NoSuchMethodException {
+        hookAllMethods("com.android.server.telecom.MiuiScamReminder", lpparam.classLoader, "isPotentialInCfummi", new MethodHook() {
+            @Override
+            protected void after(MethodHookParam param) throws Throwable {
+                param.setResult("");
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/TelecomFragment.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/TelecomFragment.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2024 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.ui.fragment;
+
+import com.sevtinge.hyperceiler.R;
+import com.sevtinge.hyperceiler.ui.fragment.base.SettingsPreferenceFragment;
+
+public class TelecomFragment extends SettingsPreferenceFragment {
+    @Override
+    public int getContentResId() {
+        return R.xml.telecom;
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1772,4 +1772,9 @@
     <string name="headtip_tip_long_press_to_copy">您可以长按或双击后选择文本进行操作，或者复制并反馈给开发者。</string>
     <string name="happy_birthday_hyperceiler">今天是 HyperCeiler 的生日！\n感谢与您岁月相伴之恩，愿来年再续前缘，共赴风雨，携手并进！</string>
 
+    <!--通话管理-->
+    <string name="telecom">通话管理</string>
+    <string name="scam_reminder_bypass_caption">允许直接拨打呼叫转移MMI码</string>
+    <string name="scam_reminder_bypass_description">允许直接拨打类似**21*8#的MMI码来开启呼叫转移</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1725,4 +1725,10 @@
     <string name="ic_qs_title_autobrightness">Auto Brightness</string>
     <string name="ic_qs_title_vowifi1">VoWiFi SIM1</string>
     <string name="ic_qs_title_vowifi2">VoWiFi SIM2</string>
+
+    <!--Telecom-->
+    <string name="telecom">Phone Calls</string>
+    <string name="scam_reminder_bypass_caption">Allow Dail call-forwarding MMI code directly</string>
+    <string name="scam_reminder_bypass_description">Allow Dail MMI Code like **21*8# to enable call-forwarding directly</string>
+
 </resources>

--- a/app/src/main/res/xml/prefs_main.xml
+++ b/app/src/main/res/xml/prefs_main.xml
@@ -58,6 +58,13 @@
             android:title="@string/incallui" />
 
         <com.sevtinge.hyperceiler.prefs.PreferenceHeader
+            android:fragment="com.sevtinge.hyperceiler.ui.fragment.TelecomFragment"
+            android:icon="@drawable/ic_call"
+            android:key="prefs_key_telecom"
+            android:summary="com.android.server.telecom"
+            android:title="@string/telecom" />
+
+        <com.sevtinge.hyperceiler.prefs.PreferenceHeader
             android:fragment="com.sevtinge.hyperceiler.ui.fragment.MmsFragment"
             android:icon="@drawable/ic_mms"
             android:key="prefs_key_mms"

--- a/app/src/main/res/xml/prefs_set_homepage_entrance.xml
+++ b/app/src/main/res/xml/prefs_set_homepage_entrance.xml
@@ -79,6 +79,14 @@
 
     <SwitchPreference
         android:defaultValue="true"
+        android:icon="@drawable/ic_phone"
+        android:key="prefs_key_telecom_state"
+        android:layout="@layout/preference_header"
+        android:summary="com.android.server.telecom"
+        android:title="@string/telecom" />
+
+    <SwitchPreference
+        android:defaultValue="true"
         android:icon="@drawable/ic_downloads"
         android:key="prefs_key_downloads_state"
         android:layout="@layout/preference_header"

--- a/app/src/main/res/xml/telecom.xml
+++ b/app/src/main/res/xml/telecom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:myLocation="@string/telecom">
+    <PreferenceCategory>
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_scam_reminder_bypass"
+            android:title="@string/scam_reminder_bypass_caption"
+            android:summary="@string/scam_reminder_bypass_description"/>
+
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
由于**的限制，现在直接拨打类似**21*8#的MMI码会导致无法成功呼出，会有**提示请”在设置中开启呼叫转移“。
本PR则取消此限制。

继续使用此功能，需要在运营商开通呼叫转移业务（因为**的原因，目前呼叫转移业务基本均被取消），方可成功开启呼叫转移，否则依然提示MMI码无效。