### PR TITLE
修复“为每个应用管理语言”失效的问题、飞行模式下可开启热点

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/XposedInit.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/XposedInit.java
@@ -28,6 +28,7 @@ import com.sevtinge.hyperceiler.module.hook.systemframework.CleanShareMenu;
 import com.sevtinge.hyperceiler.module.hook.systemframework.ScreenRotation;
 import com.sevtinge.hyperceiler.module.hook.systemframework.ToastBlur;
 import com.sevtinge.hyperceiler.module.hook.systemframework.UnlockAlwaysOnDisplay;
+import com.sevtinge.hyperceiler.module.hook.systemframework.network.FlightModeHotSpot;
 import com.sevtinge.hyperceiler.module.hook.systemsettings.VolumeSeparateControlForSettings;
 import com.sevtinge.hyperceiler.module.skip.SystemFrameworkForCorePatch;
 
@@ -71,5 +72,7 @@ public class XposedInit extends BaseXposedInit implements IXposedHookZygoteInit,
         }
         init(lpparam);
         new SystemFrameworkForCorePatch().handleLoadPackage(lpparam);
+        if (mPrefsMap.getBoolean("system_framework_network_flightmode_hotspot"))
+            new FlightModeHotSpot().handleLoadPackage(lpparam);
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/network/FlightModeHotSpot.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/network/FlightModeHotSpot.java
@@ -1,0 +1,51 @@
+package com.sevtinge.hyperceiler.module.hook.systemframework.network;
+
+import com.sevtinge.hyperceiler.module.base.tool.HookTool;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+public class FlightModeHotSpot implements IXposedHookLoadPackage {
+
+    @Override
+    public void handleLoadPackage(XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
+        if (lpparam.packageName.equals("android")) {
+            try {
+                XposedHelpers.findAndHookMethod("com.android.server.SystemServiceManager", lpparam.classLoader,
+                        "loadClassFromLoader", String.class, ClassLoader.class, new XC_MethodHook() {
+                            @Override
+                            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                                try {
+                                    String clzName = (String) param.args[0];
+                                    ClassLoader cl = (ClassLoader) param.args[1];
+                                    if (clzName.equals("com.android.server.wifi.WifiService")) {
+                                        Class<?> cls = XposedHelpers.findClass("com.android.server.wifi.WifiServiceImpl.SoftApCallbackInternal", cl);
+                                        XposedHelpers.findAndHookMethod("com.android.server.wifi.sap.MiuiWifiApManager", cl, "resetSoftApStateIfNeeded",
+                                                cls, int.class, boolean.class, boolean.class,
+                                                new XC_MethodHook() {
+                                                    @Override
+                                                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                                                        param.setResult(false);
+                                                    }
+                                                });
+                                    }
+                                } catch (Throwable t) {
+                                    XposedBridge.log("[FlightModeHotSpot]:Hook MiuiWifiApManager Failed, the reason is=" + Objects.requireNonNull(t.getCause()) +
+                                            " stackTrace=" + Arrays.toString(t.getStackTrace()));
+                                }
+                            }
+                        });
+            } catch (Throwable t) {
+                XposedBridge.log("[FlightModeHotSpot]:Hook classloader defined by MIUI failed, the reason is=" + Objects.requireNonNull(t.getCause()) +
+                        " stackTrace=" + Arrays.toString(t.getStackTrace()));
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemsettings/LanguageMenuShowAllApps.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemsettings/LanguageMenuShowAllApps.java
@@ -24,16 +24,21 @@ import com.sevtinge.hyperceiler.module.base.BaseHook;
 
 import java.util.Objects;
 
-import de.robv.android.xposed.XC_MethodHook;
-
 public class LanguageMenuShowAllApps extends BaseHook {
     @Override
     public void init() throws NoSuchMethodException {
         findAndHookMethod("android.util.FeatureFlagUtils", "isEnabled", Context.class, String.class, new MethodHook() {
             @Override
-            protected void before(MethodHookParam param) throws Throwable {
+            protected void before(MethodHookParam param) {
                 String param1 = (String) param.args[1];
                 if (Objects.equals(param1, "settings_app_locale_opt_in_enabled")) param.setResult(false);
+            }
+        });
+
+        findAndHookMethod("com.android.settings.applications.AppLocaleUtil", "isAppLocaleSupported", Context.class, String.class, new MethodHook() {
+            @Override
+            protected void before(MethodHookParam param) {
+                param.setResult(true);
             }
         });
     }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -401,6 +401,8 @@
     <string name="phone_n28_desc">支持 n28 频段 (NR)</string>
     <string name="phone_n5_n8">解锁 n5/n8 频段</string>
     <string name="phone_n5_n8_desc">在拨号界面输入 *#*#65686633#*#* 以打开 n5/n8 频段，若显示 \"enable N5 and N8 Mode\"，则开启成功</string>
+    <string name="phone_flightmode_hotspot">飞行模式下可开启热点</string>
+    <string name="phone_flightmode_hotspot_desc">允许在飞行模式下开启 WiFi 热点</string>
 
     <string name="system_framework_screen_title">显示与通知</string>
     <string name="system_framework_core_title">底层</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,8 @@
     <string name="phone_n28_desc">Support n28 Band (NR)</string>
     <string name="phone_n5_n8">n5/n8 Band</string>
     <string name="phone_n5_n8_desc">Enter *#*#65686633#*#* on the dial interface to Support n5/n8 Band. If it shows \"enable N5 and N8 Mode\", the feature will enable successfully.</string>
+    <string name="phone_flightmode_hotspot">Allow FlightMode Hotspot</string>
+    <string name="phone_flightmode_hotspot_desc">Allow open WiFi Hotspot in FlightMode</string>
     <string name="phone_additional_network_settings">Additional Network Settings</string>
 
     <string name="system_framework_screen_title">Display &amp; Notifications</string>

--- a/app/src/main/res/xml/framework_phone.xml
+++ b/app/src/main/res/xml/framework_phone.xml
@@ -38,6 +38,12 @@
             android:summary="@string/phone_n28_desc"
             android:title="@string/phone_n28" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_system_framework_network_flightmode_hotspot"
+            android:summary="@string/phone_flightmode_hotspot_desc"
+            android:title="@string/phone_flightmode_hotspot" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
修复“为每个应用管理语言”失效的问题，现在可以对任何应用设置语言了。
飞行模式下可开启热点，暂未作ui绕过，可以使用小艾同学、VPN热点来进行测试，不开启此功能，飞行模式下开热点会返回TETHER_ERROR_INTERNAL_ERROR，开启此功能重启，则不会有此问题。