### PR TITLE
fix: double spacing in app restart box

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/base/BaseSettingsActivity.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/base/BaseSettingsActivity.java
@@ -76,6 +76,12 @@ public abstract class BaseSettingsActivity extends BaseActivity {
         String isSystem = getResources().getString(R.string.restart_app_desc, appLabel);
         String isOther = getResources().getString(R.string.restart_app_desc, " " + appLabel + " ");
 
+        isSystem = isSystem.replace("  ", " ");
+        isOther = isOther.replace("  ", " ");
+
+        isSystem = isSystem.replaceAll("^\\s+|\\s+$", "");
+        isOther = isOther.replaceAll("^\\s+|\\s+$", "");
+
         new AlertDialog.Builder(this)
             .setCancelable(false)
             .setTitle(getResources().getString(R.string.soft_reboot) + " " + appLabel)


### PR DESCRIPTION
Fixed an error that displayed the string like this: Are you sure you want to restart now  XXX ?
instead of : Are you sure you want to restart now XXX?