### PR TITLE
解决 MIUI 14 上 "禁用体验优化" 不生效

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/securitycenter/other/LockOneHundredPoints.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/securitycenter/other/LockOneHundredPoints.kt
@@ -27,6 +27,8 @@ import com.sevtinge.hyperceiler.module.base.*
 import com.sevtinge.hyperceiler.module.base.dexkit.*
 import com.sevtinge.hyperceiler.module.base.dexkit.DexKitTool.toMethod
 import org.luckypray.dexkit.query.enums.*
+import java.io.*
+
 
 object LockOneHundredPoints : BaseHook() {
     private val score by lazy {
@@ -61,12 +63,19 @@ object LockOneHundredPoints : BaseHook() {
                returnConstant(null)
             }
 
-        logI(TAG, lpparam.packageName, "LockOneHundredPoints method is $scoreOld and $score")
+        try {
+            logI(TAG, lpparam.packageName, "LockOneHundredPoints old method is $scoreOld")
+            scoreOld.createHook {
+                replace { 0 }
+            }
+            return
+        } catch (e: Exception) {
+            logE(TAG, lpparam.packageName, "LockOneHundredPoints hook old Failed: ${e.message}")
+        }
+
+        logI(TAG, lpparam.packageName, "LockOneHundredPoints method is $score")
         score.createHook {
             replace { 100 }
-        }
-        scoreOld.createHook {
-            replace { 0 }
         }
     }
 }


### PR DESCRIPTION
禁用体验优化再 MIUI 上不生效

```
[ 2024-07-27T12:47:10.431     1000:  7301:  7301 I/LSPosed-Bridge  ] [HyperCeiler][E][com.miui.securitycenter][LockOneHundredPoints]: Hook Failed: org.luckypray.dexkit.exceptions.NoResultException: No result found for query
	at org.luckypray.dexkit.result.BaseDataList.single(DataCollections.kt:137)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints.score_delegate$lambda$4$lambda$3(LockOneHundredPoints.kt:42)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints.$r8$lambda$gFmh7XfhjPj25cZvE9Ho5o7ncVI(Unknown Source:0)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints$$ExternalSyntheticLambda3.dexkit(D8$$SyntheticClass:0)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getElement(DexKit.java:487)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getElementAndWriteCache(DexKit.java:285)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.run(DexKit.java:277)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getDexKitBridge(DexKit.java:269)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getDexKitBridge(DexKit.java:226)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints.score_delegate$lambda$4(LockOneHundredPoints.kt:33)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints.$r8$lambda$0YaE4X_2xcb0QCsy8wYoTfZANU4(Unknown Source:0)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints.getScore(LockOneHundredPoints.kt:32)
	at com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints.init(LockOneHundredPoints.kt:64)
	at com.sevtinge.hyperceiler.module.base.BaseHook.onCreate(BaseHook.java:46)
	at com.sevtinge.hyperceiler.module.base.BaseModule.initHook(BaseModule.java:102)
	at com.sevtinge.hyperceiler.module.app.SecurityCenter.SecurityCenterT.handleLoadPackage(SecurityCenterT.java:112)
	at com.sevtinge.hyperceiler.module.base.BaseModule.init(BaseModule.java:79)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.sevtinge.hyperceiler.module.base.BaseXposedInit.invoke(BaseXposedInit.java:217)
	at com.sevtinge.hyperceiler.module.base.BaseXposedInit.invokeHookInit(BaseXposedInit.java:200)
	at com.sevtinge.hyperceiler.module.base.BaseXposedInit.init(BaseXposedInit.java:133)
	at com.sevtinge.hyperceiler.XposedInit.handleLoadPackage(XposedInit.java:73)
	at de.robv.android.xposed.IXposedHookLoadPackage$Wrapper.handleLoadPackage(Unknown Source:2)
	at de.robv.android.xposed.callbacks.XC_LoadPackage.call(Unknown Source:6)
	at de.robv.android.xposed.callbacks.XCallback.callAll(Unknown Source:26)
	at E.afterHookedMethod(Unknown Source:207)
	at de.robv.android.xposed.XposedBridge$AdditionalHookInfo.callback(Unknown Source:147)
	at LSPHooker_.getClassLoader(Unknown Source:8)
	at android.app.LoadedApk.getResources(LoadedApk.java:1398)
	at android.app.ContextImpl.createAppContext(ContextImpl.java:3100)
	at android.app.ContextImpl.createAppContext(ContextImpl.java:3092)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7090)
	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2241)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:211)
	at android.os.Looper.loop(Looper.java:300)
	at android.app.ActivityThread.main(ActivityThread.java:8395)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)
```