### PR TITLE
解决 MIUI14 上 "禁用安全守护提示" 不生效

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/packageinstaller/DisableSafeModelTip.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/packageinstaller/DisableSafeModelTip.kt
@@ -33,7 +33,7 @@ object DisableSafeModelTip : BaseHook() {
                 matcher {
                     addUsingStringsEquals("android.provider.MiuiSettings\$Ad")
                 }
-            }.single().getMethodInstance(lpparam.classLoader)
+            }.firstOrNull()?.getMethodInstance(lpparam.classLoader)
         }.toMethod().createHook {
             returnConstant(false)
         }


### PR DESCRIPTION
解决 MIUI14 上 "禁用安全守护提示" 不生效

```
[ 2024-07-27T14:11:26.225    10120: 27052: 27052 I/LSPosed-Bridge  ] [HyperCeiler][E][com.miui.packageinstaller][DisableSafeModelTip]: Hook Failed: org.luckypray.dexkit.exceptions.NonUniqueResultException: query did not return a unique result: 2
	at org.luckypray.dexkit.result.BaseDataList.single(DataCollections.kt:141)
	at com.sevtinge.hyperceiler.module.hook.packageinstaller.DisableSafeModelTip.init$lambda$2(DisableSafeModelTip.kt:36)
	at com.sevtinge.hyperceiler.module.hook.packageinstaller.DisableSafeModelTip.$r8$lambda$yelhEkpoRDyekT4KIteVZwshY9s(Unknown Source:0)
	at com.sevtinge.hyperceiler.module.hook.packageinstaller.DisableSafeModelTip$$ExternalSyntheticLambda0.dexkit(D8$$SyntheticClass:0)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getElement(DexKit.java:487)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getElementAndWriteCache(DexKit.java:285)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.run(DexKit.java:277)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getDexKitBridge(DexKit.java:269)
	at com.sevtinge.hyperceiler.module.base.dexkit.DexKit.getDexKitBridge(DexKit.java:226)
	at com.sevtinge.hyperceiler.module.hook.packageinstaller.DisableSafeModelTip.init(DisableSafeModelTip.kt:31)
	at com.sevtinge.hyperceiler.module.base.BaseHook.onCreate(BaseHook.java:46)
	at com.sevtinge.hyperceiler.module.base.BaseModule.initHook(BaseModule.java:102)
	at com.sevtinge.hyperceiler.module.app.PackageInstaller.handleLoadPackage(PackageInstaller.java:50)
	at com.sevtinge.hyperceiler.module.base.BaseModule.init(BaseModule.java:79)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.sevtinge.hyperceiler.module.base.BaseXposedInit.invoke(BaseXposedInit.java:217)
	at com.sevtinge.hyperceiler.module.base.BaseXposedInit.invokeHookInit(BaseXposedInit.java:200)
	at com.sevtinge.hyperceiler.module.base.BaseXposedInit.init(BaseXposedInit.java:133)
	at com.sevtinge.hyperceiler.XposedInit.handleLoadPackage(XposedInit.java:73)
	at de.robv.android.xposed.IXposedHookLoadPackage$Wrapper.handleLoadPackage(Unknown Source:2)
	at de.robv.android.xposed.callbacks.XC_LoadPackage.call(Unknown Source:6)
	at de.robv.android.xposed.callbacks.XCallback.callAll(Unknown Source:26)
	at E.afterHookedMethod(Unknown Source:207)
	at de.robv.android.xposed.XposedBridge$AdditionalHookInfo.callback(Unknown Source:147)
	at LSPHooker_.getClassLoader(Unknown Source:8)
	at android.app.LoadedApk.getResources(LoadedApk.java:1398)
	at android.app.ContextImpl.createAppContext(ContextImpl.java:3100)
	at android.app.ContextImpl.createAppContext(ContextImpl.java:3092)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7090)
	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2241)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:211)
	at android.os.Looper.loop(Looper.java:300)
	at android.app.ActivityThread.main(ActivityThread.java:8395)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
```