### PR TITLE
状态栏功率添加 '功率总显示正值' 选项

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/statusbar/device/DisplayHardwareDetail.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/statusbar/device/DisplayHardwareDetail.java
@@ -61,6 +61,7 @@ public class DisplayHardwareDetail extends BaseHook {
     boolean isBatteryAtRight;
     /*boolean hasRightIcon = false;
     boolean hasLeftIcon = false;*/
+    boolean powerAbs;
 
     Class<?> mDependency;
     Class<?> mChargeUtils;
@@ -108,6 +109,7 @@ public class DisplayHardwareDetail extends BaseHook {
 
         isTempAtRight = mPrefsMap.getBoolean("system_ui_statusbar_temp_right_show");
         isBatteryAtRight = mPrefsMap.getBoolean("system_ui_statusbar_battery_right_show");
+        powerAbs = mPrefsMap.getBoolean("system_ui_statusbar_battery_power_abs");
 
         if (isNewNetworkStyle()) {
             mStatusbarTextIconLayoutResId = R.layout.statusbar_text_icon_new;
@@ -356,6 +358,7 @@ public class DisplayHardwareDetail extends BaseHook {
                                     } catch (NumberFormatException e) {
                                         logE(TAG, DisplayHardwareDetail.this.lpparam.packageName, "get POWER_SUPPLY_CURRENT_NOW failed", e);
                                     }
+                                    int currNow = rawCurr;
                                     String preferred = "mA";
                                     if (mPrefsMap.getBoolean("system_ui_statusbar_battery_electric_current")) { // 电流始终显示正值
                                         rawCurr = Math.abs(rawCurr);
@@ -380,7 +383,12 @@ public class DisplayHardwareDetail extends BaseHook {
                                         }
                                         if (powerNow != null)
                                             voltVal = Integer.parseInt(powerNow) / 1000f / 1000f;
-                                        String simpleWatt = String.format(Locale.getDefault(), "%.2f", Math.abs(voltVal * rawCurr) / 1000);
+
+                                        float wattVal = voltVal * currNow / 1000;
+                                        if (powerAbs) {
+                                            wattVal = Math.abs(wattVal);
+                                        }
+                                        String simpleWatt = String.format(Locale.getDefault(), "%.2f", wattVal);
                                         String splitChar = mPrefsMap.getBoolean("system_ui_statusbar_battery_line_show")
                                             ? " " : "\n";
                                         batteryInfo = simpleWatt + powerUnit + splitChar + currVal + currUnit;
@@ -397,7 +405,12 @@ public class DisplayHardwareDetail extends BaseHook {
                                         }
                                         if (powerNow != null)
                                             voltVal = Integer.parseInt(powerNow) / 1000f / 1000f;
-                                        String simpleWatt = String.format(Locale.getDefault(), "%.2f", Math.abs(voltVal * rawCurr) / 1000);
+
+                                        float wattVal = voltVal * currNow / 1000;
+                                        if (powerAbs) {
+                                            wattVal = Math.abs(wattVal);
+                                        }
+                                        String simpleWatt = String.format(Locale.getDefault(), "%.2f", wattVal);
                                         batteryInfo = simpleWatt + powerUnit;
                                     } else {
                                         batteryInfo = currVal + currUnit;

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -800,6 +800,7 @@
     <string name="system_ui_statusbar_battery_disable">隐藏单位</string>
     <string name="system_ui_statusbar_battery_right_show">右侧显示</string>
     <string name="system_ui_statusbar_battery_electric_current">电流总显示正值</string>
+    <string name="system_ui_statusbar_battery_power_abs">功率总显示正值</string>
     <string name="system_ui_statusbar_battery_line_show">单排显示</string>
     <string name="system_ui_statusbar_battery_opposite">反序</string>
     <string name="system_ui_statusbar_battery_only_changing_show">仅在充电时显示</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -781,6 +781,7 @@
     <string name="system_ui_statusbar_battery_disable">Hide units</string>
     <string name="system_ui_statusbar_battery_right_show">Show on the right</string>
     <string name="system_ui_statusbar_battery_electric_current">The current always shows a positive value</string>
+    <string name="system_ui_statusbar_battery_power_abs">The power always shows a positive value</string>
     <string name="system_ui_statusbar_battery_line_show">Single row display</string>
     <string name="system_ui_statusbar_battery_opposite">Reverse order</string>
     <string name="system_ui_statusbar_battery_only_changing_show">Show only when charging</string>

--- a/app/src/main/res/xml/system_ui_status_bar_hardware_detail_indicator.xml
+++ b/app/src/main/res/xml/system_ui_status_bar_hardware_detail_indicator.xml
@@ -54,6 +54,12 @@
             android:title="@string/system_ui_statusbar_battery_electric_current" />
 
         <SwitchPreference
+            android:defaultValue="true"
+            android:dependency="prefs_key_system_ui_statusbar_battery_enable"
+            android:key="prefs_key_system_ui_statusbar_battery_power_abs"
+            android:title="@string/system_ui_statusbar_battery_power_abs" />
+
+        <SwitchPreference
             android:defaultValue="false"
             android:dependency="prefs_key_system_ui_statusbar_battery_enable"
             android:key="prefs_key_system_ui_statusbar_battery_line_show"


### PR DESCRIPTION
功率总显示正值默认开启(和当前默认行为一致). 关闭此选项后, 未充电时功率值显示负数.