### PR TITLE
开放 '自定义导航栏' 设置, 并修复导航栏设置不生效

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/navigation/NavigationCustom.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/navigation/NavigationCustom.java
@@ -31,22 +31,22 @@ public class NavigationCustom extends BaseHook {
         float mNavigationFrameHeightLand = ((float) mPrefsMap.getInt("system_ui_navigation_frame_custom_height_land", 100) / 10);
 
         try {
-            mResHook.setDensityReplacement("com.android.systemui", "dimen", "navigation_bar_height", mNavigationHeight);
+            mResHook.setDensityReplacement("*", "dimen", "navigation_bar_height", mNavigationHeight);
         } catch (Exception e) {
             logE(TAG, this.lpparam.packageName, "navigation_bar_height error", e);
         }
         try {
-            mResHook.setDensityReplacement("com.android.systemui", "dimen", "navigation_bar_height_landscape", mNavigationHeightLand);
+            mResHook.setDensityReplacement("*", "dimen", "navigation_bar_height_landscape", mNavigationHeightLand);
         } catch (Exception e) {
             logE(TAG, this.lpparam.packageName, "navigation_bar_height_landscape error", e);
         }
         try {
-            mResHook.setDensityReplacement("com.android.systemui", "dimen", "navigation_bar_frame_height", mNavigationFrameHeight);
+            mResHook.setDensityReplacement("*", "dimen", "navigation_bar_frame_height", mNavigationFrameHeight);
         } catch (Exception e) {
             logE(TAG, this.lpparam.packageName, "navigation_bar_frame_height error", e);
         }
         try {
-            mResHook.setDensityReplacement("com.android.systemui", "dimen", "navigation_bar_frame_height_landscape", mNavigationFrameHeightLand);
+            mResHook.setDensityReplacement("*", "dimen", "navigation_bar_frame_height_landscape", mNavigationFrameHeightLand);
         } catch (Exception e) {
             logE(TAG, this.lpparam.packageName, "navigation_bar_frame_height_landscape error", e);
         }

--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/systemui/NavigationSettings.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/systemui/NavigationSettings.java
@@ -18,7 +18,6 @@
  */
 package com.sevtinge.hyperceiler.ui.fragment.systemui;
 
-import android.provider.Settings;
 import android.view.View;
 
 import com.sevtinge.hyperceiler.R;
@@ -26,12 +25,9 @@ import com.sevtinge.hyperceiler.ui.base.BaseSettingsActivity;
 import com.sevtinge.hyperceiler.ui.fragment.base.SettingsPreferenceFragment;
 import com.sevtinge.hyperceiler.utils.KillApp;
 
-import moralnorm.preference.PreferenceCategory;
 import moralnorm.preference.SwitchPreference;
 
 public class NavigationSettings extends SettingsPreferenceFragment {
-    SwitchPreference customNav;
-    PreferenceCategory mNav;
     SwitchPreference navigation;
 
     @Override
@@ -47,22 +43,9 @@ public class NavigationSettings extends SettingsPreferenceFragment {
         );
     }
 
-    private boolean isGestureNavigationEnabled() {
-        var defaultNavigationMode = 0;
-        var gestureNavigationMode = 2;
-
-        return Settings.Secure.getInt(requireContext().getContentResolver(), "navigation_mode", defaultNavigationMode) == gestureNavigationMode;
-    }
-
     @Override
     public void initPrefs() {
-        customNav = findPreference("prefs_key_system_ui_navigation_custom");
-        mNav = findPreference("prefs_key_system_ui_navigation");
         navigation = findPreference("prefs_key_system_ui_hide_navigation_bar");
-        if (customNav != null) {
-            mNav.setEnabled(!isGestureNavigationEnabled());
-            mNav.setVisible(mNav.isEnabled());
-        }
         navigation.setOnPreferenceChangeListener((preference, o) -> {
             KillApp.killApps("com.miui.home", "com.android.systemui");
             return true;

--- a/app/src/main/res/xml/system_ui_navigation.xml
+++ b/app/src/main/res/xml/system_ui_navigation.xml
@@ -24,7 +24,6 @@
 
         <SwitchPreference
             android:defaultValue="false"
-            android:enabled="false"
             android:key="prefs_key_system_ui_navigation_custom"
             android:title="@string/system_ui_navigation_custom" />
 


### PR DESCRIPTION
NavigationHeight 也可以用来控制手势栏高度. 因此, 无论 navigation_mode 为何值, 均开放设置.

同时, 调整hook参数, 解决导航栏设置不生效的问题.

在 miui 14.0.23 上测试正常.