### PR TITLE
解决MIUI下网速更新间隔非1秒时网速显示错误

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/statusbar/network/old/NetworkSpeed.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/statusbar/network/old/NetworkSpeed.kt
@@ -217,7 +217,7 @@ object NetworkSpeed : BaseHook() {
                         else "${humanReadableByteCount(it.args[0] as Context, rxSpeed)}$rxArrow"
 
                         // 计算总网速
-                        val ax = humanReadableByteCount(it.args[0] as Context, newTxBytesFixed + newRxBytesFixed)
+                        val ax = humanReadableByteCount(it.args[0] as Context, txSpeed + rxSpeed)
 
                         // 是否隐藏慢速的判定
                         val isLowSpeed = hideLow && (txSpeed + rxSpeed) < lowLevel


### PR DESCRIPTION
MIUI 状态栏网速默认更新间隔为4s, 显示时未除以时间间隔, 导致网速显示错误.