### PR TITLE
Removed "\" from tips

### DIFF
--- a/app/src/main/assets/tips/tips
+++ b/app/src/main/assets/tips/tips
@@ -3,36 +3,36 @@
 // Or you can delete the original content, not necessarily according to the original content
 // You can annotate with "//" on a line, note that it only works on a separate line
 
-Here\'s a tip!
+Here's a tip!
 You can support us by donating in About > Support.
 Want to contact to developer? Telegram: @Sevtinge_PM_bot or BiliBili: @绀漓丨Sevtinge.
-Want to join the official group? Telegram@hyperceiler or search 247909573 in QQ.
+Want to join the official group? Telegram: @hyperceiler or search 247909573 in QQ.
 HyperCeiler = HyperOS + Ceiler, Ceiler = Ceil + er.
 Guess how many more times you have to see this tip again?
 Make HyperOS/MIUI Great Again!
-You\'re welcome to follow on GitHub: @sevtinge or BiliBili: @绀漓丨Sevtinge.
-The ideal utopia doesn\'t exist in reality.
-Do good deeds, and don\'t ask about the future.
+You're welcome to follow on GitHub: @sevtinge or BiliBili: @绀漓丨Sevtinge.
+The ideal utopia doesn't exist in reality.
+Do good deeds, and don't ask about the future.
 The developers don't do divination, except for Ling Qiqi.
-I\'ve kept some bugs so you know you\'re using HyperCeiler.
+I've kept some bugs so you know you're using HyperCeiler.
 Did you know? In fact, tips is all nonsense.
-Did you know? HyperCeiler\'s birthday is on May 1, and Sevtinge\'s birthday is on February 2.
+Did you know? HyperCeiler's birthday is on May 1, and Sevtinge's birthday is on February 2.
 HyperCeiler is broken! It must not be a problem with HyperCeiler!
-It\'s another day of wanting to refactor in RUST.
+It's another day of wanting to refactor in RUST.
 If you are a man, open source.
 60800220501180233
 HyperCeiler is the system app with the highest battery drain.
-If there is no special annotation for the function that is gray, it means that the function is abnormal and isn\'t planned to be opened to users for the time being.
+If there is no special annotation for the function that is gray, it means that the function is abnormal and isn't planned to be opened to users for the time being.
 There has never been a bug in the Canary version.
 HyperCeiler started!
 Beware of Furuicon~ (whispering)
 Ling Qiqi has obsessive-compulsive disorder and always wants to clean up HyperCeiler, but it backfires (cry~
 This is a tip from 2.x~
-I don\'t understand why Xiaomi doesn\'t do these user-friendly features.
+I don't understand why Xiaomi doesn't do these user-friendly features.
 Improve the stability of the module and optimize the module fluency.
 The system has been destroyed.
-System UI isn\'t responding.
-Please don\'t report FeSO₄ issues, thank you for your cooperation.
+System UI isn't responding.
+Please don't report FeSO₄ issues, thank you for your cooperation.
 Users just need to update the module, but developers have many things to consider.
 Come on, come on, new bugs coming out of the oven.
 At every moment, a new opportunity.


### PR DESCRIPTION
The backslash appears in tips within the app, making reading difficult.