### PR TITLE
添加 '清理文本上下文菜单' 功能

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/data/adapter/AppDataAdapter.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/data/adapter/AppDataAdapter.java
@@ -86,7 +86,10 @@ public class AppDataAdapter extends ArrayAdapter<AppData> implements IEditCallba
 
         // appEdit.setText(appInfo.packageName);
         mSelecte.setChecked(shouldSelect(appInfo.packageName));
-        mSelecte.setVisibility(mMode == AppPicker.LAUNCHER_MODE || mMode == AppPicker.APP_OPEN_MODE ? View.VISIBLE : View.GONE);
+        mSelecte.setVisibility(mMode == AppPicker.LAUNCHER_MODE ||
+                mMode == AppPicker.APP_OPEN_MODE ||
+                mMode == AppPicker.PROCESS_TEXT_MODE ?
+                View.VISIBLE : View.GONE);
         // Log.e(TAG, "getView: " + appInfo.label, null);
         return view;
     }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemFramework/Phone/SystemFrameworkT.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemFramework/Phone/SystemFrameworkT.java
@@ -33,6 +33,7 @@ import com.sevtinge.hyperceiler.module.hook.systemframework.AppLinkVerify;
 import com.sevtinge.hyperceiler.module.hook.systemframework.BackgroundBlur;
 import com.sevtinge.hyperceiler.module.hook.systemframework.CleanOpenMenu;
 import com.sevtinge.hyperceiler.module.hook.systemframework.CleanShareMenu;
+import com.sevtinge.hyperceiler.module.hook.systemframework.CleanProcessTextMenu;
 import com.sevtinge.hyperceiler.module.hook.systemframework.ClipboardWhitelist;
 import com.sevtinge.hyperceiler.module.hook.systemframework.DeleteOnPostNotification;
 import com.sevtinge.hyperceiler.module.hook.systemframework.DisableCleaner;
@@ -119,6 +120,7 @@ public class SystemFrameworkT extends BaseModule {
         initHook(new ScreenRotation(), mPrefsMap.getBoolean("system_framework_screen_all_rotations"));
         initHook(new CleanShareMenu(), mPrefsMap.getBoolean("system_framework_clean_share_menu"));
         initHook(new CleanOpenMenu(), mPrefsMap.getBoolean("system_framework_clean_open_menu"));
+        initHook(new CleanProcessTextMenu(), mPrefsMap.getBoolean("system_framework_clean_process_text_menu"));
         initHook(new AllowUntrustedTouch(), mPrefsMap.getBoolean("system_framework_allow_untrusted_touch"));
         if (isMoreAndroidVersion(34))
             initHook(new AllowUntrustedTouchForU(), mPrefsMap.getBoolean("system_framework_allow_untrusted_touch"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/CleanProcessTextMenu.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/CleanProcessTextMenu.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2024 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.module.hook.systemframework;
+
+import static com.sevtinge.hyperceiler.utils.devicesdk.SystemSDKKt.isMoreAndroidVersion;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.os.BadParcelableException;
+import android.os.Handler;
+
+import com.sevtinge.hyperceiler.module.base.BaseHook;
+import com.sevtinge.hyperceiler.utils.prefs.PrefsChangeObserver;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import de.robv.android.xposed.XposedHelpers;
+
+public class CleanProcessTextMenu extends BaseHook {
+
+    Class<?> mPackageManagerService;
+
+    @Override
+    public void init() {
+
+        mPackageManagerService = findClassIfExists("com.android.server.pm.PackageManagerService");
+
+        findAndHookMethod(mPackageManagerService, "systemReady", new MethodHook() {
+            @Override
+            protected void after(MethodHookParam param) throws Throwable {
+                Context mContext = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
+                Handler mHandler = (Handler) XposedHelpers.getObjectField(param.thisObject, "mHandler");
+                new PrefsChangeObserver(mContext, mHandler, true,
+                        "prefs_key_system_framework_clean_process_text_apps");
+            }
+        });
+
+        MethodHook hook = new MethodHook() {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected void after(MethodHookParam param) throws Throwable {
+                try {
+                    if (param.args[0] == null) return;
+                    Intent origIntent = (Intent) param.args[0];
+                    String action = origIntent.getAction();
+                    if (action == null) return;
+                    if (!action.equals(Intent.ACTION_PROCESS_TEXT))
+                        return;
+                    Intent intent = (Intent) origIntent.clone();
+                    if (intent.hasExtra("HyperCeiler") &&
+                            intent.getBooleanExtra("HyperCeiler", false))
+                        return;
+                    Set<String> selectedApps = mPrefsMap.getStringSet("system_framework_clean_process_text_apps");
+                    List<ResolveInfo> resolved = (List<ResolveInfo>) param.getResult();
+                    ResolveInfo resolveInfo;
+                    Context mContext = (Context) XposedHelpers.getObjectField(param.thisObject, "mContext");
+                    PackageManager pm = mContext.getPackageManager();
+                    Iterator<ResolveInfo> itr = resolved.iterator();
+                    while (itr.hasNext()) {
+                        resolveInfo = itr.next();
+                        boolean removeOriginal =
+                                selectedApps.contains(resolveInfo.activityInfo.packageName) ||
+                                selectedApps.contains(resolveInfo.activityInfo.packageName + "|0");
+                        boolean removeDual =
+                                selectedApps.contains(resolveInfo.activityInfo.packageName + "|999");
+                        boolean hasDual = false;
+                        try {
+                            hasDual = XposedHelpers.callMethod(pm, "getPackageInfoAsUser",
+                                    resolveInfo.activityInfo.packageName, 0, 999) != null;
+                        } catch (Throwable ignore) {
+                        }
+                        if ((removeOriginal && !hasDual) || removeOriginal && hasDual && removeDual)
+                            itr.remove();
+                    }
+                    param.setResult(resolved);
+                } catch (Throwable t) {
+                    if (!(t instanceof BadParcelableException))
+                        logE(TAG, CleanProcessTextMenu.this.lpparam.packageName, t);
+                }
+            }
+        };
+
+        String ActQueryService = isMoreAndroidVersion(33) ?
+                "com.android.server.pm.ComputerEngine" :
+                "com.android.server.pm.PackageManagerService$ComputerEngine";
+        hookAllMethods(ActQueryService, lpparam.classLoader, "queryIntentActivitiesInternal", hook);
+        logD("hook query PROCESS_TEXT success");
+    }
+}

--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/framework/OtherSettings.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/framework/OtherSettings.java
@@ -48,6 +48,7 @@ public class OtherSettings extends SettingsPreferenceFragment implements Prefere
 
     Preference mCleanShareApps;
     Preference mCleanOpenApps;
+    Preference mCleanProcessTextApps;
     Preference mAutoStart;
     Preference mClipboardWhitelistApps;
     SwitchPreference mEntry;
@@ -75,6 +76,7 @@ public class OtherSettings extends SettingsPreferenceFragment implements Prefere
     public void initPrefs() {
         mCleanShareApps = findPreference("prefs_key_system_framework_clean_share_apps");
         mCleanOpenApps = findPreference("prefs_key_system_framework_clean_open_apps");
+        mCleanProcessTextApps = findPreference("prefs_key_system_framework_clean_process_text_apps");
         mAutoStart = findPreference("prefs_key_system_framework_auto_start_apps");
         mClipboardWhitelistApps = findPreference("prefs_key_system_framework_clipboard_whitelist_apps");
         mVerifyDisable = findPreference("prefs_key_system_framework_disable_verify_can_ve_disabled");
@@ -119,6 +121,14 @@ public class OtherSettings extends SettingsPreferenceFragment implements Prefere
         mCleanOpenApps.setOnPreferenceClickListener(preference -> {
             Intent intent = new Intent(getActivity(), SubPickerActivity.class);
             intent.putExtra("mode", AppPicker.APP_OPEN_MODE);
+            intent.putExtra("key", preference.getKey());
+            startActivity(intent);
+            return true;
+        });
+
+        mCleanProcessTextApps.setOnPreferenceClickListener(preference -> {
+            Intent intent = new Intent(getActivity(), SubPickerActivity.class);
+            intent.putExtra("mode", AppPicker.PROCESS_TEXT_MODE);
             intent.putExtra("key", preference.getKey());
             startActivity(intent);
             return true;

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -458,6 +458,9 @@
     <string name="system_framework_clean_open_menu">清理打开方式菜单</string>
     <string name="system_framework_clean_open_apps">已选应用</string>
     <string name="system_framework_clean_open_apps_desc">选中的应用将不会出现在打开方式菜单内</string>
+    <string name="system_framework_clean_process_text_menu">清理文本上下文菜单</string>
+    <string name="system_framework_clean_process_text_apps">已选应用</string>
+    <string name="system_framework_clean_process_text_apps_desc">选中的应用将不会出现在文本上下文菜单内</string>
     <string name="system_other_flag_secure">允许截屏</string>
     <string name="system_other_flag_secure_desc">允许对任意应用进行截屏和录屏</string>
     <string name="system_other_delete_on_post_notification">移除上层显示通知</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,6 +450,9 @@
     <string name="system_framework_clean_open_menu">Clean up open with menu</string>
     <string name="system_framework_clean_open_apps">Selected apps</string>
     <string name="system_framework_clean_open_apps_desc">The selected app won\'t appear in the open with menu</string>
+    <string name="system_framework_clean_process_text_menu">Clean up text context menu</string>
+    <string name="system_framework_clean_process_text_apps">Selected apps</string>
+    <string name="system_framework_clean_process_text_apps_desc">The selected app won\'t appear in the text context menu</string>
     <string name="system_other_flag_secure">Allow screenshot</string>
     <string name="system_other_flag_secure_desc">Allows screenshots and screen recordings of any app</string>
     <string name="system_other_delete_on_post_notification">Remove the upper display notification</string>

--- a/app/src/main/res/xml/framework_other.xml
+++ b/app/src/main/res/xml/framework_other.xml
@@ -226,6 +226,17 @@
             android:summary="@string/system_framework_clean_open_apps_desc"
             android:title="@string/system_framework_clean_open_apps" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_system_framework_clean_process_text_menu"
+            android:title="@string/system_framework_clean_process_text_menu" />
+
+        <Preference
+            android:dependency="prefs_key_system_framework_clean_process_text_menu"
+            android:key="prefs_key_system_framework_clean_process_text_apps"
+            android:summary="@string/system_framework_clean_process_text_apps_desc"
+            android:title="@string/system_framework_clean_process_text_apps" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/system_framework_other_title">


### PR DESCRIPTION
Editor 等组件中选择文本时会弹出上下文菜单, APP 可在 manifest 中添加 PROCESS_TEXT action 来在此菜单中注册选项.
但 Android 没有提供管理此菜单的方式, 故添加此功能, 用于清理菜单选项.