### PR TITLE
chore: Optimize the prompt text to be consistent with other similar options

### DIFF
--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -384,11 +384,12 @@
     <string name="system_framework_disable_app_link_verify_desc">アプリ設定で対応リンクを有効化しなくても、リンクを開いたときに対応しているアプリで直接開くようにします</string>
     <string name="system_framework_clean_share_menu">共有メニューを整理する</string>
     <string name="system_framework_clean_share_apps">選択中のアプリ</string>
-    <string name="system_framework_auto_start_apps">自動起動の制限を除外</string>
     <string name="system_framework_clean_share_apps_desc">選択したアプリは共有メニューに表示されません</string>
     <string name="system_framework_clean_open_menu">「アプリで開く」メニューを整理する</string>
     <string name="system_framework_clean_open_apps">選択中のアプリ</string>
     <string name="system_framework_clean_open_apps_desc">選択したアプリは「アプリで開く」メニューに表示されません</string>
+    <string name="system_framework_auto_start_menu">自動起動の制限を除外</string>
+    <string name="system_framework_auto_start_apps">選択中のアプリ</string>
     <string name="system_other_flag_secure">スクリーンショットを許可</string>
     <string name="system_other_flag_secure_desc">あらゆるアプリでのスクリーンショットや画面録画を許可します</string>
     <string name="system_other_delete_on_post_notification">オーバーレイアプリの通知を無効化</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -393,7 +393,6 @@
     <string name="system_framework_disable_app_link_verify_desc">Reverter para abrir apps suportados diretamente ao abrir links sem habilitar links suportados nas configurações do app</string>
     <string name="system_framework_clean_share_menu">Limpar menu de compartilhamento</string>
     <string name="system_framework_clean_share_apps">Apps selecionados</string>
-    <string name="system_framework_auto_start_apps">Exceções em cadeia de restrições</string>
     <string name="system_framework_clean_share_apps_desc">O app selecionado não aparecerá no menu de compartilhamento</string>
     <string name="system_framework_clean_open_menu">Limpar menu Abrir com</string>
     <string name="system_framework_clean_open_apps">Apps selecionados</string>
@@ -401,6 +400,8 @@
     <string name="system_framework_clean_process_text_menu">Limpar menu de contexto de texto</string>
     <string name="system_framework_clean_process_text_apps">Apps selecionados</string>
     <string name="system_framework_clean_process_text_apps_desc">O app selecionado não aparecerá no menu de contexto de texto</string>
+    <string name="system_framework_auto_start_menu">Exceções em cadeia de restrições</string>
+    <string name="system_framework_auto_start_apps">Apps selecionados</string>
     <string name="system_other_flag_secure">Permitir captura de tela</string>
     <string name="system_other_flag_secure_desc">Permite capturas de tela e gravações de tela em qualquer app</string>
     <string name="system_other_delete_on_post_notification">Remover notificação da tela superior</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -394,7 +394,6 @@ Chức năng này là chức năng thử nghiệm có độ ổn định cao</st
     <string name="system_framework_disable_app_link_verify_desc">Hoàn nguyên để mở trực tiếp các ứng dụng được hỗ trợ khi mở liên kết, không cần kiểm tra liên kết được hỗ trợ trong cài đặt ứng dụng</string>
     <string name="system_framework_clean_share_menu">Dọn dẹp trình đơn chia sẻ</string>
     <string name="system_framework_clean_share_apps">Ứng dụng đã chọn</string>
-    <string name="system_framework_auto_start_apps">Loại bỏ chuỗi hạn chế</string>
     <string name="system_framework_clean_share_apps_desc">Ứng dụng đã chọn sẽ không xuất hiện trong menu chia sẻ</string>
     <string name="system_framework_clean_open_menu">Dọn dẹp mở với menu</string>
     <string name="system_framework_clean_open_apps">Ứng dụng đã lựa chọn</string>
@@ -402,6 +401,8 @@ Chức năng này là chức năng thử nghiệm có độ ổn định cao</st
     <string name="system_framework_clean_process_text_menu">Xóa menu ngữ cảnh văn bản</string>
     <string name="system_framework_clean_process_text_apps">Ứng dụng đã chọn</string>
     <string name="system_framework_clean_process_text_apps_desc">Ứng dụng đã chọn sẽ không xuất hiện trong menu ngữ cảnh văn bản</string>
+    <string name="system_framework_auto_start_menu">Loại bỏ chuỗi hạn chế</string>
+    <string name="system_framework_auto_start_apps">Ứng dụng đã chọn</string>
     <string name="system_other_flag_secure">Cho phép chụp ảnh màn hình</string>
     <string name="system_other_flag_secure_desc">Cho phép chụp ành màn hình và ghi hình bất kì ứng dụng nào</string>
     <string name="system_other_delete_on_post_notification">Xóa thông báo lớp phủ</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -458,7 +458,6 @@
     <string name="system_framework_disable_app_link_verify_desc">打开链接时恢复为直接打开支持的应用，无需在应用设置中勾选支持的链接</string>
     <string name="system_framework_clean_share_menu">清理分享菜单</string>
     <string name="system_framework_clean_share_apps">已选应用</string>
-    <string name="system_framework_auto_start_apps">限制链豁免</string>
     <string name="system_framework_clean_share_apps_desc">选中的应用将不会出现在分享菜单内</string>
     <string name="system_framework_clean_open_menu">清理打开方式菜单</string>
     <string name="system_framework_clean_open_apps">已选应用</string>
@@ -466,6 +465,9 @@
     <string name="system_framework_clean_process_text_menu">清理文本上下文菜单</string>
     <string name="system_framework_clean_process_text_apps">已选应用</string>
     <string name="system_framework_clean_process_text_apps_desc">选中的应用将不会出现在文本上下文菜单内</string>
+    <string name="system_framework_auto_start_menu">限制链豁免</string>
+    <string name="system_framework_auto_start_apps">已选应用</string>
+    <string name="system_framework_auto_start_apps_desc">选中的应用将不会被限制链限制，能够自启动</string>
     <string name="system_other_flag_secure">允许截屏</string>
     <string name="system_other_flag_secure_desc">允许对任意应用进行截屏和录屏</string>
     <string name="system_other_delete_on_post_notification">移除上层显示通知</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -439,11 +439,12 @@
     <string name="system_framework_disable_app_link_verify_desc">打開鏈接時恢復為直接打開支持嘅應用，無需喺應用設置中勾選支持嘅鏈接</string>
     <string name="system_framework_clean_share_menu">清理分享菜單</string>
     <string name="system_framework_clean_share_apps">已選應用</string>
-    <string name="system_framework_auto_start_apps">限制鏈豁免</string>
     <string name="system_framework_clean_share_apps_desc">選中嘅應用將唔會出現喺分享菜單內</string>
     <string name="system_framework_clean_open_menu">清理打開方式菜單</string>
     <string name="system_framework_clean_open_apps">已選應用</string>
     <string name="system_framework_clean_open_apps_desc">選中嘅應用將唔會出現喺打開方式菜單內</string>
+    <string name="system_framework_auto_start_menu">限制鏈豁免</string>
+    <string name="system_framework_auto_start_apps">已選應用</string>
     <string name="system_other_flag_secure">允許截屏</string>
     <string name="system_other_flag_secure_desc">允許對任意應用進行截屏同錄屏</string>
     <string name="system_other_delete_on_post_notification">移除上層顯示通知</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -380,11 +380,12 @@
     <string name="system_framework_disable_app_link_verify_desc">打開連結時還原為直接打開支援的應用程式，無需在應用程式設定中勾選支援的連結</string>
     <string name="system_framework_clean_share_menu">清理分享選單</string>
     <string name="system_framework_clean_share_apps">已選擇的應用程式</string>
-    <string name="system_framework_auto_start_apps">限制鏈豁免</string>
     <string name="system_framework_clean_share_apps_desc">選取的應用程式將不會出現在分享選單中</string>
     <string name="system_framework_clean_open_menu">清理打開方式選單</string>
     <string name="system_framework_clean_open_apps">已選擇的應用程式</string>
     <string name="system_framework_clean_open_apps_desc">選取的應用程式將不會出現在開啟方式選單中</string>
+    <string name="system_framework_auto_start_menu">限制鏈豁免</string>
+    <string name="system_framework_auto_start_apps">已選擇的應用程式</string>
     <string name="system_other_flag_secure">允許截圖</string>
     <string name="system_other_flag_secure_desc">允許對任意應用程式進行截圖和錄製螢幕</string>
     <string name="system_other_delete_on_post_notification">移除上層顯示通知</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,7 +445,6 @@
     <string name="system_framework_disable_app_link_verify_desc">Revert to opening supported apps directly when opening links without enabling supported links in app settings</string>
     <string name="system_framework_clean_share_menu">Clean up share menu</string>
     <string name="system_framework_clean_share_apps">Selected apps</string>
-    <string name="system_framework_auto_start_apps">Restriction chain exemptions</string>
     <string name="system_framework_clean_share_apps_desc">The selected app won\'t appear in the share menu</string>
     <string name="system_framework_clean_open_menu">Clean up open with menu</string>
     <string name="system_framework_clean_open_apps">Selected apps</string>
@@ -453,6 +452,8 @@
     <string name="system_framework_clean_process_text_menu">Clean up text context menu</string>
     <string name="system_framework_clean_process_text_apps">Selected apps</string>
     <string name="system_framework_clean_process_text_apps_desc">The selected app won\'t appear in the text context menu</string>
+    <string name="system_framework_auto_start_menu">Restriction chain exemptions</string>
+    <string name="system_framework_auto_start_apps">Selected apps</string>
     <string name="system_other_flag_secure">Allow screenshot</string>
     <string name="system_other_flag_secure_desc">Allows screenshots and screen recordings of any app</string>
     <string name="system_other_delete_on_post_notification">Remove the upper display notification</string>

--- a/app/src/main/res/xml/framework_other.xml
+++ b/app/src/main/res/xml/framework_other.xml
@@ -253,11 +253,14 @@
     <PreferenceCategory android:title="@string/system_framework_other_title">
         <SwitchPreference
             android:defaultValue="false"
-            android:key="prefs_key_system_framework_auto_start_apps_enable"
-            android:title="@string/system_framework_auto_start_apps" />
+            android:key="prefs_key_system_framework_auto_start_menu"
+            android:title="@string/system_framework_auto_start_menu" />
+
         <Preference
-            android:dependency="prefs_key_system_framework_auto_start_apps_enable"
+            android:dependency="prefs_key_system_framework_auto_start_menu"
             android:key="prefs_key_system_framework_auto_start_apps"
+            android:summary="@string/system_framework_auto_start_apps_desc"
             android:title="@string/system_framework_auto_start_apps" />
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
目前“限制链豁免”的开关打开后，会显示两个“限制链豁免”的选项。因此参照上方选项，将第二个选项的提示文本改为“已选应用”并添加相应描述。
![Screenshot_2024-10-06-23-47-49-671_com sevtinge hyperceiler](https://github.com/user-attachments/assets/c7638795-1932-4c16-bd8c-f98413937e93)