### PR TITLE
feat: Add a option to remove simlock success dialog

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SecurityCenter/SecurityCenterT.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SecurityCenter/SecurityCenterT.java
@@ -63,6 +63,7 @@ import com.sevtinge.hyperceiler.module.hook.securitycenter.other.DisableRootChec
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.FuckRiskPkg;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.LockOneHundredPoints;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.NoLowBatteryWarning;
+import com.sevtinge.hyperceiler.module.hook.securitycenter.other.RemoveSIMLockSuccessDialog;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.other.SkipCountDownLimit;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.sidebar.AddSideBarExpandReceiver;
 import com.sevtinge.hyperceiler.module.hook.securitycenter.sidebar.BlurSecurity;
@@ -123,6 +124,7 @@ public class SecurityCenterT extends BaseModule {
         initHook(DisableRootCheck.INSTANCE, mPrefsMap.getBoolean("security_center_disable_root_check"));
         initHook(FuckRiskPkg.INSTANCE, mPrefsMap.getBoolean("security_center_disable_send_malicious_app_notification"));
         initHook(NoLowBatteryWarning.INSTANCE, mPrefsMap.getBoolean("security_center_remove_low_battery_reminder"));
+        initHook(RemoveSIMLockSuccessDialog.INSTANCE, mPrefsMap.getBoolean("security_center_remove_simlock_success_dialog"));
         initHook(new UnlockFbo(), mPrefsMap.getBoolean("security_center_unlock_fbo"));
         initHook(BypassSimLockMiAccountAuth.INSTANCE, mPrefsMap.getBoolean("security_center_bypass_simlock_miaccount_auth"));
         initHook(new BypassAdbInstallVerify(), mPrefsMap.getBoolean("security_center_adb_install_verify"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemFramework/Phone/SystemFrameworkT.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemFramework/Phone/SystemFrameworkT.java
@@ -98,7 +98,7 @@ public class SystemFrameworkT extends BaseModule {
         initHook(new DisableMiuiWatermark(), mPrefsMap.getBoolean("system_framework_disable_miui_watermark"));
         initHook(new AntiQues(), mPrefsMap.getBoolean("system_settings_anti_ques"));
         // 小窗
-        initHook(new AllowAutoStart(), mPrefsMap.getBoolean("system_framework_auto_start_apps_enable"));
+        initHook(new AllowAutoStart(), mPrefsMap.getBoolean("system_framework_auto_start_apps_menu"));
         initHook(new FreeFormCount(), mPrefsMap.getBoolean("system_framework_freeform_count"));
         initHook(new FreeformBubble(), mPrefsMap.getBoolean("system_framework_freeform_bubble"));
         initHook(new DisableFreeformBlackList(), mPrefsMap.getBoolean("system_framework_disable_freeform_blacklist"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/securitycenter/other/RemoveSIMLockSuccessDialog.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/securitycenter/other/RemoveSIMLockSuccessDialog.kt
@@ -1,0 +1,45 @@
+/*
+  * This file is part of HyperCeiler.
+
+  * HyperCeiler is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU Affero General Public License as
+  * published by the Free Software Foundation, either version 3 of the
+  * License.
+
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU Affero General Public License for more details.
+
+  * You should have received a copy of the GNU Affero General Public License
+  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+  * Copyright (C) 2023-2024 HyperCeiler Contributions
+*/
+
+package com.sevtinge.hyperceiler.module.hook.securitycenter.other;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import com.sevtinge.hyperceiler.module.base.BaseHook;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedHelpers;
+
+object RemoveSIMLockSuccessDialog : BaseHook() {
+    @Throws(NoSuchMethodException::class)
+    override fun init() {
+        XposedHelpers.findAndHookMethod(
+            "com.miui.simlock.activity.SuccessDialogActivity",
+            lpparam.classLoader,
+            "onCreate",
+            Bundle::class.java,
+            object : XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    (param.thisObject as Activity).finish()
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1619,6 +1619,8 @@
     <string name="security_center_game_speed_desc">在启动游戏时倍速通过开屏动画，仅部分游戏支持</string>
     <string name="security_center_bypass_simlock_miaccount_auth">SIM 卡安全保护跳过登录验证</string>
     <string name="security_center_bypass_simlock_miaccount_auth_desc">开启 SIM 卡安全保护功能时无需登录小米账号</string>
+    <string name="security_center_remove_simlock_success_dialog">移除 SIM 卡安全保护验证成功的弹窗</string>
+    <string name="security_center_remove_simlock_success_dialog_desc">开机后不再弹窗提示 SIM 卡安全保护验证成功</string>
     <string name="security_center_aosp_app_info">添加 \"原生应用信息\" 入口</string>
     <string name="security_center_aosp_app_info_label">原生应用信息</string>
     <string name="security_center_aosp_app_manager">添加 \"原生应用管理\" 入口</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1582,6 +1582,8 @@
     <string name="security_center_game_speed_desc">When launching the game, it passes the opening screen animation at 3x speed, which is only supported by some games.</string>
     <string name="security_center_bypass_simlock_miaccount_auth">Bypass Xiaomi Account SIM security</string>
     <string name="security_center_bypass_simlock_miaccount_auth_desc">You can use this function even without logging into your Xiaomi Account.</string>
+    <string name="security_center_remove_simlock_success_dialog">Remove the dialog for successful SIM card security verification</string>
+    <string name="security_center_remove_simlock_success_dialog_desc">No more dialog after powering on the phone to indicate that the SIM card security protection has been successfully verified.</string>
     <string name="security_center_aosp_app_info_label">AOSP app info</string>
     <string name="security_center_aosp_app_info">Add AOSP app info entry</string>
     <string name="security_center_aosp_app_manager_label">AOSP app manager</string>

--- a/app/src/main/res/xml/security_center_other.xml
+++ b/app/src/main/res/xml/security_center_other.xml
@@ -147,5 +147,11 @@
             android:summary="@string/security_center_bypass_simlock_miaccount_auth_desc"
             android:title="@string/security_center_bypass_simlock_miaccount_auth" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_security_center_remove_simlock_success_dialog"
+            android:summary="@string/security_center_remove_simlock_success_dialog_desc"
+            android:title="@string/security_center_remove_simlock_success_dialog" />
+
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
移除 SIM 卡安全保护验证成功的弹窗。该弹窗会在自动验证SIM的PIN码后弹出，且无法禁用。