### PR TITLE
禁止在截屏分享页面使用小窗

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/freeform/OpenAppInFreeForm.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/freeform/OpenAppInFreeForm.java
@@ -119,6 +119,9 @@ public class OpenAppInFreeForm extends BaseHook {
         boolean openInFw = false;
         final boolean openFwWhenShare = mPrefsMap.getBoolean("system_framework_freeform_app_share");
         if (openFwWhenShare) {
+            if ("com.miui.screenshot".equals(callingPackage)) {
+                openInFw = false;
+            }
             /*if (mPrefsMap.getStringSet("system_fw_forcein_actionsend_apps").contains(pkgName)) return false;*/
             if ("com.miui.packageinstaller".equals(pkgName) && intent.getComponent().getClassName().contains("com.miui.packageInstaller.NewPackageInstallerActivity")) {
                 return true;

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/freeform/OpenAppInFreeForm.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemframework/freeform/OpenAppInFreeForm.java
@@ -120,7 +120,7 @@ public class OpenAppInFreeForm extends BaseHook {
         final boolean openFwWhenShare = mPrefsMap.getBoolean("system_framework_freeform_app_share");
         if (openFwWhenShare) {
             if ("com.miui.screenshot".equals(callingPackage)) {
-                openInFw = false;
+                return false;
             }
             /*if (mPrefsMap.getStringSet("system_fw_forcein_actionsend_apps").contains(pkgName)) return false;*/
             if ("com.miui.packageinstaller".equals(pkgName) && intent.getComponent().getClassName().contains("com.miui.packageInstaller.NewPackageInstallerActivity")) {


### PR DESCRIPTION
可以避免在截屏分享页面打开小窗分享导致的割裂体验