### PR TITLE
opt UnlockHotseatIcon

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/home/UnlockHotseatIcon.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/home/UnlockHotseatIcon.kt
@@ -18,14 +18,10 @@
 */
 package com.sevtinge.hyperceiler.module.hook.home
 
-import com.sevtinge.hyperceiler.utils.*
+import com.sevtinge.hyperceiler.module.base.tool.HookTool.MethodHook.*
 
 class UnlockHotseatIcon : HomeBaseHook() {
     override fun init() {
-        DEVICE_CONFIG.hookBeforeMethod(
-            if (isNewHome) "calHotseatMaxCount" else "getHotseatMaxCount"
-        ) {
-            it.result = 99
-        }
+        findAndHookMethod(DEVICE_CONFIG, "getHotseatMaxCount", returnConstant(99))
     }
 }


### PR DESCRIPTION
用户反馈“解锁底栏图标数量限制”功能失效，原因未知，回退统一 HOOK `getHotseatMaxCount ` 方法