### PR TITLE
feat: fix bastardized custom action buttons in media control panel

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Pad/SystemUiU.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Pad/SystemUiU.java
@@ -62,6 +62,7 @@ import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlP
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlPanelTimeViewTextSize;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaSeekBarColor;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MuteVisibleNotifications;
+import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NewBrightnessPct;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationImportanceHyperOSFix;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationRowMenu;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationWeather;
@@ -349,6 +350,7 @@ public class SystemUiU extends BaseModule {
         initHook(DisableBottomBar.INSTANCE, mPrefsMap.getBoolean("system_ui_disable_bottombar"));
         initHook(UnlockClipboard.INSTANCE, mPrefsMap.getBoolean("system_ui_unlock_clipboard"));
         initHook(new VolumeTimerValuesHook(), mPrefsMap.getBoolean("system_ui_volume_timer"));
+        initHook(NewBrightnessPct.INSTANCE, mPrefsMap.getBoolean("system_showpct_title"));
 
         // 锁屏
         initHook(new ScramblePIN(), mPrefsMap.getBoolean("system_ui_lock_screen_scramble_pin"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Pad/SystemUiV.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Pad/SystemUiV.java
@@ -59,6 +59,7 @@ import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlP
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlPanelTimeViewTextSize;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaSeekBarColor;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MuteVisibleNotifications;
+import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NewBrightnessPct;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NewFlashLight;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationImportanceHyperOSFix;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationRowMenu;
@@ -269,6 +270,7 @@ public class SystemUiV extends BaseModule {
         initHook(DisableInfinitymodeGesture.INSTANCE, mPrefsMap.getBoolean("system_ui_disable_infinitymode_gesture"));
         initHook(DisableBottomBar.INSTANCE, mPrefsMap.getBoolean("system_ui_disable_bottombar"));
         initHook(UnlockClipboard.INSTANCE, mPrefsMap.getBoolean("system_ui_unlock_clipboard"));
+        initHook(NewBrightnessPct.INSTANCE, mPrefsMap.getBoolean("system_showpct_title"));
 
         // 锁屏
         initHook(new ScramblePIN(), mPrefsMap.getBoolean("system_ui_lock_screen_scramble_pin"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Phone/SystemUiU.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Phone/SystemUiU.java
@@ -62,6 +62,7 @@ import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlP
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlPanelTimeViewTextSize;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaSeekBarColor;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MuteVisibleNotifications;
+import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NewBrightnessPct;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationImportanceHyperOSFix;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationRowMenu;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationWeather;
@@ -349,6 +350,7 @@ public class SystemUiU extends BaseModule {
         initHook(DisableBottomBar.INSTANCE, mPrefsMap.getBoolean("system_ui_disable_bottombar"));
         initHook(UnlockClipboard.INSTANCE, mPrefsMap.getBoolean("system_ui_unlock_clipboard"));
         initHook(new VolumeTimerValuesHook(), mPrefsMap.getBoolean("system_ui_volume_timer"));
+        initHook(NewBrightnessPct.INSTANCE, mPrefsMap.getBoolean("system_showpct_title"));
 
         // 锁屏
         initHook(new ScramblePIN(), mPrefsMap.getBoolean("system_ui_lock_screen_scramble_pin"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Phone/SystemUiV.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/app/SystemUI/Phone/SystemUiV.java
@@ -59,6 +59,7 @@ import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlP
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaControlPanelTimeViewTextSize;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MediaSeekBarColor;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.MuteVisibleNotifications;
+import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NewBrightnessPct;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NewFlashLight;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationImportanceHyperOSFix;
 import com.sevtinge.hyperceiler.module.hook.systemui.controlcenter.NotificationRowMenu;
@@ -285,6 +286,7 @@ public class SystemUiV extends BaseModule {
         initHook(DisableInfinitymodeGesture.INSTANCE, mPrefsMap.getBoolean("system_ui_disable_infinitymode_gesture"));
         initHook(DisableBottomBar.INSTANCE, mPrefsMap.getBoolean("system_ui_disable_bottombar"));
         initHook(UnlockClipboard.INSTANCE, mPrefsMap.getBoolean("system_ui_unlock_clipboard"));
+        initHook(NewBrightnessPct.INSTANCE, mPrefsMap.getBoolean("system_showpct_title"));
 
         // 锁屏
         initHook(new ScramblePIN(), mPrefsMap.getBoolean("system_ui_lock_screen_scramble_pin"));

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/base/tool/OtherTool.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/base/tool/OtherTool.java
@@ -173,7 +173,7 @@ public class OtherTool {
                 getTextView().setTextColor(ColorStateList.valueOf(Color.parseColor("#FFFFFFFF")));
                 getTextView().setBackground(modRes.getDrawable(R.drawable.input_background, context.getTheme()));
             } catch (Throwable err) {
-                logE("ShowVolumePct", err);
+                logE("ShowPct", err);
             }
             if (mPrefsMap.getBoolean("system_showpct_use_blur")) {
                 try {
@@ -188,7 +188,7 @@ public class OtherTool {
                     MiBlurUtils.clearMiBackgroundBlendColor(getTextView());
                     MiBlurUtils.addMiBackgroundBlendColor(getTextView(), Color.argb(a, 0, 0, 0), 101);
                 } catch (Throwable e) {
-                    logE("ShowVolumePct", e);
+                    logE("ShowPct", e);
                 }
             }
             container.addView(getTextView());

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/controlcenter/MediaButton.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/controlcenter/MediaButton.java
@@ -18,6 +18,7 @@
 */
 package com.sevtinge.hyperceiler.module.hook.systemui.controlcenter;
 
+import android.widget.ImageButton;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
@@ -40,6 +41,35 @@ public class MediaButton extends BaseHook {
 
     @Override
     public void init() throws NoSuchMethodException {
+
+        Class<?> DrawableUtils = findClassIfExists("com.miui.utils.DrawableUtils", lpparam.classLoader);
+        hookAllMethods("com.android.systemui.media.controls.ui.controller.MediaControlPanel",
+        "bindButtonCommon", new MethodHook() {
+            @Override
+            protected void before(MethodHookParam param) throws Throwable {
+                Object mediaAction = param.args[0];
+                String desc = (String) XposedHelpers.getObjectField(mediaAction, "contentDescription");
+                if ((typeCustom != 140) && 
+                    !desc.contains("Play") && !desc.contains("Pause") && 
+                    !desc.contains("Previous track") && !desc.contains("Next track")) {
+                    ImageButton button = (ImageButton) param.args[0];
+                    Drawable loadDrawable = (Drawable) XposedHelpers.getObjectField(mediaAction, "icon");
+                    Method method = DrawableUtils.getDeclaredMethod("drawable2Bitmap", Drawable.class);
+                    Bitmap bitmap = (Bitmap) method.invoke(null, loadDrawable);
+                    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, typeCustom, typeCustom, true);
+                    XposedHelpers.setObjectField(mediaAction, "icon", new BitmapDrawable(button.getContext().getResources(), scaledBitmap));
+                } else if (type != 140) {
+                    ImageButton button = (ImageButton) param.args[0];
+                    Drawable loadDrawable = (Drawable) XposedHelpers.getObjectField(mediaAction, "icon");
+                    Method method = DrawableUtils.getDeclaredMethod("drawable2Bitmap", Drawable.class);
+                    Bitmap bitmap = (Bitmap) method.invoke(null, loadDrawable);
+                    Bitmap scaledBitmap = Bitmap.createScaledBitmap(bitmap, type, type, true);
+                    XposedHelpers.setObjectField(mediaAction, "icon", new BitmapDrawable(button.getContext().getResources(), scaledBitmap));
+                }
+            }
+        });
+
+        /* HyperOS 1.0
         findAndHookMethod("com.android.systemui.media.controls.pipeline.MediaDataManager",
                 "createActionsFromState", String.class, MediaController.class, UserHandle.class,
                 new MethodHook() {
@@ -91,6 +121,7 @@ public class MediaButton extends BaseHook {
                         }
                     }
                 }
-        );
+        ); 
+        */
     }
 }

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/controlcenter/NewBrightnessPct.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/controlcenter/NewBrightnessPct.kt
@@ -1,0 +1,111 @@
+package com.sevtinge.hyperceiler.module.hook.systemui.controlcenter
+
+import android.annotation.*
+import android.view.*
+import com.github.kyuubiran.ezxhelper.ClassUtils.loadClass
+import com.github.kyuubiran.ezxhelper.ClassUtils.loadClassOrNull
+import com.github.kyuubiran.ezxhelper.HookFactory.`-Static`.createAfterHook
+import com.github.kyuubiran.ezxhelper.finders.MethodFinder.`-Static`.methodFinder
+import com.sevtinge.hyperceiler.module.base.*
+import com.sevtinge.hyperceiler.module.base.tool.*
+import com.sevtinge.hyperceiler.utils.*
+import de.robv.android.xposed.*
+
+object NewBrightnessPct : BaseHook() {
+    private val MiuiBrightnessController by lazy {
+        loadClass("com.android.systemui.controlcenter.policy.MiuiBrightnessController")
+    }
+    private val brightnessUtils by lazy {
+        loadClassOrNull("com.android.systemui.controlcenter.policy.BrightnessUtils")
+    }
+
+    fun initLoaderHook(classLoader: ClassLoader) {
+        loadClass("miui.systemui.controlcenter.panel.main.brightness.BrightnessSliderController\$seekBarListener\$1", classLoader)
+            .methodFinder().filterByName("onStartTrackingTouch")
+            .first().createAfterHook {
+                startPct(it)
+            }
+
+        loadClass("miui.systemui.controlcenter.panel.main.brightness.BrightnessPanelSliderController\$seekBarListener\$1")
+            .methodFinder().filterByName("onStartTrackingTouch")
+            .first().createAfterHook {
+                startPct(it)
+            }
+    }
+
+    private fun startPct(it: XC_MethodHook.MethodHookParam) {
+        val brightnessController =
+            it.thisObject.getObjectField("this$0")!!.getObjectField("brightnessController")
+        val cl = brightnessController!!.javaClass.classLoader
+        val controlCenterControllerImpl =
+            getObject("com.android.systemui.controlcenter.policy.ControlCenterControllerImpl", cl)
+        val controlCenterContentController =
+            getObjectArr(controlCenterControllerImpl, "controlCenter.contentController")
+        val mContext = controlCenterContentController!!.callMethod("get")!!
+            .getObjectField("content")
+        val windowView = mContext!!.callMethod("getContentView")
+        if (windowView == null) {
+            logE(TAG, lpparam.packageName, "mControlPanelContentView is null")
+            return
+        }
+        OtherTool.initPct(windowView as ViewGroup, 2, windowView.context)
+        OtherTool.getTextView().visibility = View.VISIBLE
+    }
+
+    @SuppressLint("SetTextI18n")
+    override fun init() {
+        hookAllMethods(
+            MiuiBrightnessController, "onStop",
+            object : MethodHook() {
+                override fun after(param: MethodHookParam) {
+                    OtherTool.removePct(OtherTool.getTextView())
+                }
+            })
+
+        hookAllMethods(
+            MiuiBrightnessController, "onChanged",
+            object : MethodHook() {
+                override fun after(param: MethodHookParam) {
+                    var pctTag = 0
+                    if (OtherTool.getTextView() != null && OtherTool.getTextView().tag != null) {
+                        pctTag = OtherTool.getTextView().tag as Int
+                    }
+                    if (pctTag == 0 || OtherTool.getTextView() == null) return
+                    val currentLevel = param.args[3] as Int
+                    if (brightnessUtils != null) {
+                        val maxLevel =
+                            brightnessUtils!!.getStaticObjectField("GAMMA_SPACE_MAX") as Int
+                        OtherTool.getTextView().text =
+                            ((currentLevel * 100) / maxLevel).toString() + "%"
+                    }
+                }
+            })
+    }
+
+    private fun getObject(str: String, cl: ClassLoader?): Any? {
+        val dependency = loadClass("com.android.systemui.Dependency", cl)
+        val cl2 = loadClass(str, cl)
+        val mDependency =
+            dependency.getStaticObjectField("sDependency")!!.callMethod("getDependencyInner", cl2)
+        return mDependency
+    }
+
+    private fun getObjectArr(obj: Any?, str: String): Any? {
+        if (obj == null) {
+            return null
+        }
+        val fields = str.split(".")
+        var currentObj = obj
+        for (field in fields) {
+            try {
+                currentObj = currentObj!!.getObjectField(field)
+            } catch (e: Throwable) {
+                currentObj = "ObjectFieldNotExist"
+            }
+            if (currentObj == "ObjectFieldNotExist") {
+                return "ObjectFieldNotExist"
+            }
+        }
+        return currentObj
+    }
+}

--- a/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/plugin/NewPluginHelperKt.kt
+++ b/app/src/main/java/com/sevtinge/hyperceiler/module/hook/systemui/plugin/NewPluginHelperKt.kt
@@ -51,59 +51,25 @@ object NewPluginHelperKt : BaseHook() {
         try {
             onPluginLoadedAll(factory)
 
-            when (factory.mComponentName) {
+            /*when (factory.mComponentName) {
                 factory.componentNames("miui.systemui.volume.VolumeDialogPlugin") -> {
                     val classLoader: ClassLoader = factory.pluginCtxRef.get()!!.classLoader
                     logD(TAG, lpparam.packageName, "Plugin for sysui volume loaded.")
-
-                    if (mPrefsMap.getBoolean("system_ui_plugin_enable_volume_blur"))
-                        EnableVolumeBlur.initEnableVolumeBlur(classLoader)
-                    if (mPrefsMap.getBoolean("system_cc_volume_showpct_title"))
-                        NewShowVolumePct.initLoader(classLoader) // 声音百分比
-                    if (mPrefsMap.getBoolean("system_ui_unlock_super_volume"))
-                        NewSuperVolume.initSuperVolume(classLoader) // 超大音量
-                    if (mPrefsMap.getBoolean("system_framework_volume_separate_control") &&
-                        mPrefsMap.getBoolean("system_framework_volume_separate_slider"))
-                        NotificationVolumeSeparateSlider.initHideDeviceControlEntry(classLoader)
                 }
 
                 factory.componentNames("miui.systemui.miplay.MiPlayPluginImpl") -> {
                     val classLoader: ClassLoader = factory.pluginCtxRef.get()!!.classLoader
                     logD(TAG, lpparam.packageName, "Plugin for sysui mipay loaded.")
-
-                    if (mPrefsMap.getStringAsInt("system_ui_control_center_mi_play_entry", 0) != 0)
-                        HideMiPlayEntry.initHideMiPlayEntry(classLoader)
-                }
-
-                factory.componentNames("miui.systemui.controlcenter.MiuiControlCenter") -> {
-                    val classLoader: ClassLoader = factory.pluginCtxRef.get()!!.classLoader
-                    logD(TAG, lpparam.packageName, "Plugin for sysui control center loaded.")
-
-                    if (mPrefsMap.getBoolean("system_ui_control_center_hide_edit_botton"))
-                        HideEditButton.initHideEditButton(classLoader)
                 }
 
                 factory.componentNames("miui.systemui.notification.NotificationStatPluginImpl") -> {
                     val classLoader: ClassLoader = factory.pluginCtxRef.get()!!.classLoader
                     logD(TAG, lpparam.packageName, "Plugin for sysui NotificationStatPluginImpl loaded.")
-
-                    if (mPrefsMap.getBoolean("system_ui_statusbar_music_switch"))
-                        FocusNotifLyric.initLoader(classLoader);
                 }
 
                 else -> {
                     val classLoader: ClassLoader = factory.pluginCtxRef.get()!!.classLoader
 
-                    if (mPrefsMap.getStringAsInt("system_ui_control_center_mi_smart_hub_entry", 0) != 0)
-                        HideMiSmartHubEntry.initHideMiSmartHubEntry(classLoader)
-                    if (mPrefsMap.getStringAsInt("system_ui_control_center_device_ctrl_entry", 0) != 0)
-                        HideDeviceControlEntry.initHideDeviceControlEntry(classLoader)
-                    if (mPrefsMap.getStringAsInt("system_ui_control_center_cc_bluetooth_tile_style", 1) > 1)
-                        BluetoothTileStyle.initHideDeviceControlEntry(classLoader)
-                    if (mPrefsMap.getStringAsInt("system_ui_control_center_hide_operator", 0) == 3)
-                        ShowDeviceName.initShowDeviceName(classLoader)
-                    if (mPrefsMap.getBoolean("system_ui_control_center_disable_device_managed"))
-                        DisableDeviceManaged.initDisableDeviceManaged(classLoader)
                     // logD(TAG, lpparam.packageName, "Plugin is ${factory.mComponentName}")
                     // 仅备份当前可用注入 ClassLoader
                     // miui.systemui.volume.VolumeDialogPlugin
@@ -116,7 +82,7 @@ object NewPluginHelperKt : BaseHook() {
                     // miui.systemui.notification.FocusNotificationPluginImpl
                     // miui.systemui.notification.unimportant.UnimportantSdkPluginImpl
                 }
-            }
+            }*/
         } catch (_: Exception) {}
     }
 
@@ -125,6 +91,8 @@ object NewPluginHelperKt : BaseHook() {
         val classLoader: ClassLoader = factory.pluginCtxRef.get()!!.classLoader
         val mCardStyleTiles = getTileList()
 
+        if (mPrefsMap.getBoolean("system_ui_control_center_hide_edit_botton"))
+            HideEditButton.initHideEditButton(classLoader)
         if (mPrefsMap.getBoolean("systemui_plugin_card_tiles_enabled") &&
             mPrefsMap.getString("systemui_plugin_card_tiles", "").isNotEmpty()) {
             CustomCardTiles.initCustomCardTiles(classLoader, mCardStyleTiles)            //A
@@ -136,6 +104,35 @@ object NewPluginHelperKt : BaseHook() {
         ) {
             QSColor.pluginHook(classLoader)
         }
+
+        if (mPrefsMap.getBoolean("system_ui_plugin_enable_volume_blur"))
+            EnableVolumeBlur.initEnableVolumeBlur(classLoader)
+        if (mPrefsMap.getBoolean("system_ui_unlock_super_volume"))
+            NewSuperVolume.initSuperVolume(classLoader) // 超大音量
+        if (mPrefsMap.getBoolean("system_framework_volume_separate_control") &&
+            mPrefsMap.getBoolean("system_framework_volume_separate_slider"))
+            NotificationVolumeSeparateSlider.initHideDeviceControlEntry(classLoader)
+        if (mPrefsMap.getBoolean("system_cc_volume_showpct_title"))
+            NewShowVolumePct.initLoader(classLoader) // 声音百分比
+        if (mPrefsMap.getBoolean("system_showpct_title"))
+            NewBrightnessPct.initLoaderHook(classLoader)
+
+        if (mPrefsMap.getStringAsInt("system_ui_control_center_mi_play_entry", 0) != 0)
+            HideMiPlayEntry.initHideMiPlayEntry(classLoader)
+
+        if (mPrefsMap.getBoolean("system_ui_statusbar_music_switch"))
+            FocusNotifLyric.initLoader(classLoader);
+
+        if (mPrefsMap.getStringAsInt("system_ui_control_center_mi_smart_hub_entry", 0) != 0)
+            HideMiSmartHubEntry.initHideMiSmartHubEntry(classLoader)
+        if (mPrefsMap.getStringAsInt("system_ui_control_center_device_ctrl_entry", 0) != 0)
+            HideDeviceControlEntry.initHideDeviceControlEntry(classLoader)
+        if (mPrefsMap.getStringAsInt("system_ui_control_center_cc_bluetooth_tile_style", 1) > 1)
+            BluetoothTileStyle.initHideDeviceControlEntry(classLoader)
+        if (mPrefsMap.getStringAsInt("system_ui_control_center_hide_operator", 0) == 3)
+            ShowDeviceName.initShowDeviceName(classLoader)
+        if (mPrefsMap.getBoolean("system_ui_control_center_disable_device_managed"))
+            DisableDeviceManaged.initDisableDeviceManaged(classLoader)
 
         if (mPrefsMap.getBoolean("system_ui_other_default_plugin_theme"))
             DefaultPluginTheme.initDefaultPluginTheme(classLoader)

--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/app/systemui/SystemUIOtherSettings.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/fragment/app/systemui/SystemUIOtherSettings.java
@@ -48,7 +48,6 @@ public class SystemUIOtherSettings extends DashboardFragment {
     SwitchPreference mPower;
     SwitchPreference mDisableBluetoothRestrict; // 禁用蓝牙临时关闭
     SwitchPreference mPctUseBlur;
-    SwitchPreference mShowPct;
     SwitchPreference mFuckSG;
     SwitchPreference mTimer;
     SwitchPreference mPluginThemeBlur;
@@ -70,7 +69,6 @@ public class SystemUIOtherSettings extends DashboardFragment {
         mVolume = findPreference("prefs_key_system_ui_disable_volume");
         mPower = findPreference("prefs_key_system_ui_disable_power");
         mPctUseBlur = findPreference("prefs_key_system_showpct_use_blur");
-        mShowPct = findPreference("prefs_key_system_showpct_title");
         mFuckSG = findPreference("prefs_key_system_ui_move_log_to_miui");
         mTimer = findPreference("prefs_key_system_ui_volume_timer");
         mPluginThemeBlur = findPreference("prefs_key_system_ui_other_default_plugin_theme");
@@ -82,7 +80,6 @@ public class SystemUIOtherSettings extends DashboardFragment {
         mDisableInfinitymodeGesture.setVisible(isMoreHyperOSVersion(1f) && isMoreAndroidVersion(34) && isPad());
         mBottomBar.setVisible(isMoreHyperOSVersion(1f) && isMoreAndroidVersion(34));
         mPctUseBlur.setVisible(isMoreHyperOSVersion(1f));
-        mShowPct.setVisible(!isMoreHyperOSVersion(1f));
         mFuckSG.setVisible(isMoreHyperOSVersion(2f));
         mTimer.setVisible(!isMoreAndroidVersion(35));
         mPluginThemeBlur.setVisible(isMoreHyperOSVersion(1f));

--- a/app/src/main/res/xml/guard_provider.xml
+++ b/app/src/main/res/xml/guard_provider.xml
@@ -21,13 +21,15 @@
     app:myLocation="@string/guard_provider"
     app:myLocationHyper="@string/guard_provider_hyperos"
     app:quick_restart="com.miui.guardprovider">
-    <SwitchPreference
-        android:defaultValue="false"
-        android:key="prefs_key_guard_provider_disable_root_check"
-        android:title="@string/guard_provider_disable_root_check" />
-    <SwitchPreference
-        android:title="@string/guard_provider_disable_upload_applist"
-        android:key="prefs_key_disable_upload_applist"
-        android:defaultValue="false" />
+    <PreferenceCategory>
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_guard_provider_disable_root_check"
+            android:title="@string/guard_provider_disable_root_check" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_disable_upload_applist"
+            android:title="@string/guard_provider_disable_upload_applist" />
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
OS 2.0 updated layout for notification media controls which subsequently led to incompatibility with previous hooks. 

This patch targets the action binding method directly and should reduce overall resource usage.
