### PR TITLE
fix: BackGesture area height modification fails on new homeApp

### DIFF
--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/home/navigation/BackGestureAreaHeight.java
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/home/navigation/BackGestureAreaHeight.java
@@ -21,11 +21,39 @@ package com.sevtinge.hyperceiler.hook.module.hook.home.navigation;
 import android.view.WindowManager;
 
 import com.sevtinge.hyperceiler.hook.module.base.BaseHook;
+import de.robv.android.xposed.XposedHelpers;
 
 public class BackGestureAreaHeight extends BaseHook {
     @Override
     public void init() {
-        findAndHookMethodSilently("com.miui.home.recents.GestureStubView",  "getGestureStubWindowParam", new MethodHook() {
+        try {   //适用于5.39.10929+
+            findAndHookMethod("com.miui.home.recents.GestureStubView", "updateGestureTouchHeight", new replaceHookedMethod() {
+                @Override
+                protected Object replace(MethodHookParam param) throws Throwable {
+                    Object thiz = param.thisObject;
+
+                    int mRotation = XposedHelpers.getIntField(thiz, "mRotation");
+                    boolean mIsInMultiWindowMode = XposedHelpers.getBooleanField(thiz, "mIsInMultiWindowMode");
+                    boolean mIsInMinimizedMultiWindowMode = XposedHelpers.getBooleanField(thiz, "mIsInMinimizedMultiWindowMode");
+                    int mScreenHeight = XposedHelpers.getIntField(thiz, "mScreenHeight");
+                    int mScreenWidth = XposedHelpers.getIntField(thiz, "mScreenWidth");
+
+                    float f = (float) mPrefsMap.getInt("home_navigation_back_area_height", 60) / 100;
+
+                    if (mRotation == 0 || mRotation == 2) {
+                        if (mIsInMultiWindowMode && !mIsInMinimizedMultiWindowMode) { f = 1.0f; }
+                        int gestureTouchHeight = (int) (mScreenHeight * f);
+                        XposedHelpers.setIntField(thiz, "mGestureTouchHeight", gestureTouchHeight);
+                    } else {
+                        int gestureTouchHeight = (int) (mScreenWidth * f);
+                        XposedHelpers.setIntField(thiz, "mGestureTouchHeight", gestureTouchHeight);
+                    }
+
+                    return null;
+                }
+            });
+        } catch (NoSuchMethodError e) { //旧版
+            findAndHookMethodSilently("com.miui.home.recents.GestureStubView",  "getGestureStubWindowParam", new MethodHook() {
             @Override
             protected void after(final MethodHookParam param) throws Throwable {
                 WindowManager.LayoutParams lp = (WindowManager.LayoutParams)param.getResult();
@@ -34,5 +62,6 @@ public class BackGestureAreaHeight extends BaseHook {
                 param.setResult(lp);
             }
         });
+        }
     }
 }


### PR DESCRIPTION
修复：侧滑手势高度修改后，在新版系统桌面上引发返回手势失效问题