### PR TITLE
fix: 修复在桌面11402（或后续）版本中dock栏背景解锁动画闪烁问题

### DIFF
--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/home/dock/DockCustomNew.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/home/dock/DockCustomNew.kt
@@ -36,6 +36,7 @@ import com.sevtinge.hyperceiler.hook.utils.getObjectFieldAs
 import com.sevtinge.hyperceiler.hook.utils.hookAfterMethod
 import io.github.kyuubiran.ezxhelper.core.finder.MethodFinder.`-Static`.methodFinder
 import io.github.kyuubiran.ezxhelper.core.util.ClassUtil.loadClass
+import io.github.kyuubiran.ezxhelper.core.util.ClassUtil.loadClassOrNull
 import io.github.kyuubiran.ezxhelper.xposed.dsl.HookFactory.`-Static`.createAfterHook
 import java.lang.reflect.Method
 import java.util.function.Consumer
@@ -50,10 +51,19 @@ object DockCustomNew : BaseHook() {
     }
 
     private val showAnimationLambda by lazy {
+        val isNewAnimationCompat =
+            loadClassOrNull("com.miui.home.launcher.compat.UserPresentAnimationCompatV12Phone") == null
+
+        val targetAnimationCompatName = if (isNewAnimationCompat) {
+            "com.miui.home.launcher.compat.UserPresentAnimationCompatPhone"
+        } else {
+            "com.miui.home.launcher.compat.UserPresentAnimationCompatV12Phone"
+        }
+
         DexKit.findMember("ShowAnimationLambda") { bridge ->
             bridge.findMethod {
                 matcher {
-                    declaredClass("com.miui.home.launcher.compat.UserPresentAnimationCompatV12Phone")
+                    declaredClass(targetAnimationCompatName)
                     addInvoke {
                         name = "conversionValueFrom3DTo2D"
                     }


### PR DESCRIPTION
从11284版本开始，小米旗舰机与红米系统包中的"系统桌面"疑似来自不同的分支，目前不严谨的判定11322-11328-11333-11402为小米分支，其余版本为红米分支，两个分支特性有所区别。

在小米分支（红米分支目前版本还未发现相关改动）桌面更新11402后，由于删除了`UserPresentAnimationCompatV12Phone`类，使得为`showAnimationLambda`赋值的dexkit查找失败，从而导致dock栏的背景解锁动画出现异常，如下图所示。

此修改增加了新的类名，并保持了之前版本的兼容性。

![f1ffc172c845cddb85621cbfafd4bf90](https://github.com/user-attachments/assets/5aa8f58c-052e-4d4e-a109-33ade1c777f6)

