### PR TITLE
feat: 新增自定义息屏焦点布局

### DIFF
--- a/library/common-ui/java/main/res/values-zh-rCN/strings_app.xml
+++ b/library/common-ui/java/main/res/values-zh-rCN/strings_app.xml
@@ -787,6 +787,7 @@
     <string name="system_ui_statusbar_music_cusiom_notific_title">通知栏显示设置</string>
     <string name="system_ui_statusbar_music_show_notific_title">显示通知歌词</string>
     <string name="system_ui_statusbar_music_hide_aod_title">不在息屏下显示焦点通知</string>
+    <string name="system_ui_statusbar_music_show_aod_mode_title">使用自定义焦点息屏布局</string>
     <string name="system_ui_statusbar_music_cusiom_statusbar_title">状态栏显示设置</string>
     <string name="system_ui_statusbar_music_hide_clock_title">隐藏状态栏时钟</string>
     <string name="system_ui_statusbar_music_hide_clock_desc">显示焦点歌词时隐藏状态栏时钟，并调整下拉通知中心的动画</string>

--- a/library/common-ui/java/main/res/values/strings_app.xml
+++ b/library/common-ui/java/main/res/values/strings_app.xml
@@ -767,6 +767,7 @@
     <string name="system_ui_statusbar_music_cusiom_notific_title">Notification bar display settings</string>
     <string name="system_ui_statusbar_music_show_notific_title">Show notification lyrics</string>
     <string name="system_ui_statusbar_music_hide_aod_title">Don\'t show focus notifications on the locked screen</string>
+    <string name="system_ui_statusbar_music_show_aod_mode_title">Use custom focus screen-off layout</string>
     <string name="system_ui_statusbar_music_cusiom_statusbar_title">Status bar display settings</string>
     <string name="system_ui_statusbar_music_hide_clock_title">Hide status bar clock</string>
     <string name="system_ui_statusbar_music_hide_clock_desc">Hide the status bar clock when showing focused lyrics</string>

--- a/library/common-ui/java/main/res/xml/system_ui_status_bar_music.xml
+++ b/library/common-ui/java/main/res/xml/system_ui_status_bar_music.xml
@@ -52,6 +52,12 @@
             android:key="prefs_key_system_ui_statusbar_music_hide_aod"
             android:title="@string/system_ui_statusbar_music_hide_aod_title" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:dependency="prefs_key_system_ui_statusbar_music_show_notific"
+            android:key="prefs_key_system_ui_statusbar_music_show_aod_mode"
+            android:title="@string/system_ui_statusbar_music_show_aod_mode_title" />
+
         <SeekBarPreferenceCompat
             app:defaultValue="15"
             android:key="prefs_key_system_ui_statusbar_music_size_n"

--- a/library/common-ui/java/main/res/xml/system_ui_status_bar_music.xml
+++ b/library/common-ui/java/main/res/xml/system_ui_status_bar_music.xml
@@ -49,19 +49,20 @@
         <SwitchPreference
             android:defaultValue="false"
             android:dependency="prefs_key_system_ui_statusbar_music_show_notific"
+            android:disableDependentsState="true"
             android:key="prefs_key_system_ui_statusbar_music_hide_aod"
             android:title="@string/system_ui_statusbar_music_hide_aod_title" />
 
         <SwitchPreference
             android:defaultValue="false"
-            android:dependency="prefs_key_system_ui_statusbar_music_show_notific"
+            android:dependency="prefs_key_system_ui_statusbar_music_hide_aod"
             android:key="prefs_key_system_ui_statusbar_music_show_aod_mode"
             android:title="@string/system_ui_statusbar_music_show_aod_mode_title" />
 
         <SeekBarPreferenceCompat
-            app:defaultValue="15"
             android:key="prefs_key_system_ui_statusbar_music_size_n"
             android:title="@string/system_ui_statusbar_mobile_type_font_size"
+            app:defaultValue="15"
             app:defaultValueTitle="@string/array_default"
             app:format="%s dp"
             app:maxValue="32"
@@ -87,32 +88,32 @@
             android:title="@string/system_ui_statusbar_music_click_clock_title" />
 
         <SeekBarPreferenceCompat
-            app:defaultValue="18"
             android:key="prefs_key_system_ui_statusbar_music_speed"
             android:title="@string/system_ui_statusbar_music_speed_title"
+            app:defaultValue="18"
             app:defaultValueTitle="@string/array_default"
-            app:showDividerValue="10"
-            app:format="%s f"
+            app:format="%s x"
             app:maxValue="48"
             app:minValue="5"
+            app:showDividerValue="10"
             app:stepValue="1" />
 
         <SeekBarPreferenceCompat
-            app:defaultValue="12"
             android:key="prefs_key_system_ui_statusbar_music_scroll_delay"
             android:title="@string/system_ui_statusbar_music_scroll_delay_title"
+            app:defaultValue="12"
             app:defaultValueTitle="@string/array_default"
-            app:showDividerValue="10"
-            app:format="%s f"
+            app:format="%s x"
             app:maxValue="24"
             app:minValue="3"
+            app:showDividerValue="10"
             app:stepValue="1" />
 
         <SeekBarPreferenceCompat
-            app:defaultValue="0"
             android:key="prefs_key_system_ui_statusbar_music_width"
             android:summary="@string/system_ui_statusbar_music_width_desc"
             android:title="@string/system_ui_statusbar_music_width_title"
+            app:defaultValue="0"
             app:defaultValueTitle="@string/array_default"
             app:format="%s dp"
             app:maxValue="32"

--- a/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
+++ b/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
@@ -19,16 +19,16 @@
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="100dp"
-    android:layout_height="40dp"
+    android:layout_height="wrap_content"
     android:gravity="center"
-    android:orientation="horizontal"
-    android:padding="5dp">
+    android:orientation="horizontal">
 
     <ImageView
         android:id="@+id/focusicon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-         android:layout_marginEnd="2dp"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="2dp"
         android:scaleType="centerCrop" />
 
     <TextView

--- a/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
+++ b/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
@@ -18,6 +18,7 @@
   ~ Copyright (C) 2023-2025 HyperCeiler Contributions
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="100dp"
     android:layout_height="wrap_content"
     android:gravity="center"
@@ -25,11 +26,12 @@
 
     <ImageView
         android:id="@+id/focusicon"
-        android:layout_width="25dp"
-        android:layout_height="25dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_marginTop="2dp"
         android:layout_marginBottom="2dp"
-        android:scaleType="centerCrop" />
+        android:scaleType="centerCrop"
+        tools:ignore="ContentDescription" />
 
     <TextView
         android:id="@id/focuslyric"

--- a/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
+++ b/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
@@ -18,7 +18,6 @@
   ~ Copyright (C) 2023-2025 HyperCeiler Contributions
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="100dp"
     android:layout_height="40dp"
     android:gravity="center"
@@ -27,9 +26,9 @@
 
     <ImageView
         android:id="@+id/focusicon"
-        android:layout_width="25dp"
-        android:layout_height="25dp"
-        android:layout_marginTop="2dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+         android:layout_marginEnd="2dp"
         android:scaleType="centerCrop" />
 
     <TextView
@@ -41,4 +40,5 @@
         android:layout_marginEnd="5dp"
         android:maxLines="5"
         android:textSize="18sp" />
+
 </LinearLayout>

--- a/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
+++ b/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This file is part of HyperCeiler.
+  ~
+  ~ HyperCeiler is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  ~
+  ~ Copyright (C) 2023-2025 HyperCeiler Contributions
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="100dp"
+    android:layout_height="40dp"
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:padding="5dp">
+
+    <ImageView
+        android:id="@+id/focusicon"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:layout_marginTop="2dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@id/focuslyric"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:breakStrategy="simple"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="5dp"
+        android:maxLines="5"
+        android:textSize="18sp" />
+</LinearLayout>

--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/pack/systemui/MusicBaseHook.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/pack/systemui/MusicBaseHook.kt
@@ -100,7 +100,7 @@ abstract class MusicBaseHook : BaseHook() {
         val modRes = OtherTool.getModuleRes(context)
         val isClickClock = mPrefsMap.getBoolean("system_ui_statusbar_music_click_clock")
         val launchIntent = context.packageManager.getLaunchIntentForPackage(extraData.packageName)
-        //图标处理
+        // 图标处理
         val basebitmap = base64ToDrawable(extraData.base64Icon)
         val bitmap = basebitmap ?: context.packageManager.getActivityIcon(launchIntent!!).toBitmap()
         val icon: Icon = Icon.createWithBitmap(bitmap).apply { if (basebitmap != null) setTint(Color.WHITE) }


### PR DESCRIPTION
- 新增“使用自定义焦点息屏布局”开关，允许用户选择自定义的 AOD 焦点通知布局。
- 为 AOD 模式创建新的布局文件 `focusaodlyric_layout.xml`，其中包含图标和文本。
- 更新 `MusicBaseHook.kt` 以支持新的 AOD 模式，包括：
  - 处理图标的亮色和暗色模式。
  - 根据 AOD 模式选择不同的 RemoteViews。
  - 为 `FocusApi.senddiyFocus` 添加 `pictickerdark` 和 `rvAod` 参数。
- 在中英文语言资源中添加了相应的字符串。