### PR TITLE
fix: 焦点歌词滚动逻辑优化

### DIFF
--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
@@ -178,8 +178,11 @@ object FocusNotifLyric : MusicBaseHook() {
             val lineWidth = textView.layout?.getLineWidth(0)
 
             if (lineWidth != null) {
+                // 重设最大滚动宽度,只能滚动到文本结束
                 m.setFloatField("mMaxScroll", lineWidth - width)
+                // 重设速度
                 m.setFloatField("mPixelsPerMs", speed)
+                // 移除回调,防止滚动结束之后重置滚动位置
                 m.setObjectField("mRestartCallback", Choreographer.FrameCallback {})
 
                 XposedHelpers.setAdditionalStaticField(textView, "is_scrolling", 1)

--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
@@ -200,7 +200,7 @@ object FocusNotifLyric : MusicBaseHook() {
 
     private fun computeScrollDuration(lineWidth: Float, width: Float, speed: Float): Long {
         val distance = (lineWidth - width).coerceAtLeast(0f)
-        return (distance / speed).toLong() + 100L // 加100ms缓冲
+        return (distance / speed).toLong()
     }
 
 

--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
@@ -199,9 +199,11 @@ object FocusNotifLyric : MusicBaseHook() {
     }
 
     private fun computeScrollDuration(lineWidth: Float, width: Float, speed: Float): Long {
-        val distance = (lineWidth - width).coerceAtLeast(0f)
-        return (distance / speed).toLong()
+        val maxScroll = (lineWidth - width).coerceAtLeast(0f) // 与 mMaxScroll 一致
+        val pixelsPerMs = speed // 与 mPixelsPerMs 一致
+        return if (pixelsPerMs > 0) (maxScroll / pixelsPerMs).toLong() else 0L
     }
+
 
 
     override fun onStop() {


### PR DESCRIPTION
- 优化焦点歌词滚动逻辑，仅当歌词内容变化且与当前 `textView.text` 不同时才更新并重新滚动，避免不必要的重置和闪烁。
- 修复 `startScroll` 调用逻辑，确保在滚动完成后从 `runnablePool` 中移除任务，避免潜在的内存泄漏和重复执行。
- 滚动完成后，将 `is_scrolling` 状态置为 0。
- 新增 `computeScrollDuration` 方法用于计算滚动所需时间。
- 在 `startScroll` 中，滚动完成后移除 `runnablePool` 中的任务引用。