### PR TITLE
fix: 优化焦点歌词滚动逻辑

### DIFF
--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
@@ -31,7 +31,6 @@ import com.sevtinge.hyperceiler.hook.utils.setFloatField
 import com.sevtinge.hyperceiler.hook.utils.setLongField
 import com.sevtinge.hyperceiler.hook.utils.setObjectField
 import de.robv.android.xposed.XC_MethodHook
-import de.robv.android.xposed.XposedHelpers
 import io.github.kyuubiran.ezxhelper.core.finder.ConstructorFinder.`-Static`.constructorFinder
 import io.github.kyuubiran.ezxhelper.core.finder.MethodFinder.`-Static`.methodFinder
 import io.github.kyuubiran.ezxhelper.core.util.ClassUtil.loadClass
@@ -46,6 +45,7 @@ import kotlinx.coroutines.launch
 // co-author git@lingqiqi5211
 object FocusNotifLyric : MusicBaseHook() {
     private var speed = -0.1f
+    private var lyricgundonjiesu = true
     private var lastLyric = ""
     private val runnablePool = mutableMapOf<Int, Runnable>()
     private val focusTextViewList = mutableListOf<TextView>()
@@ -140,13 +140,14 @@ object FocusNotifLyric : MusicBaseHook() {
         focusTextViewList.forEach { textView ->
             textView.post {
                 if (lastLyric == textView.text) {
-                    if (XposedHelpers.getAdditionalStaticField(textView, "is_scrolling") == 1) {
-                        val m0 = textView.getObjectFieldOrNull("mMarquee")
-                        m0?.apply {
+                    lyricgundonjiesu = true
+                    val m0 = textView.getObjectFieldOrNull("mMarquee")
+                    m0?.apply {
                             // 设置速度并且调用停止函数,重置歌词位置
                             setFloatField("mPixelsPerMs", 0f)
                             callMethod("stop")
-                        }
+                            lyricgundonjiesu = true
+
                     }
                     textView.text = lyric
                     lastLyric = lyric
@@ -154,7 +155,15 @@ object FocusNotifLyric : MusicBaseHook() {
                 val key = textView.hashCode()
                 val startScroll = runnablePool.getOrPut(key) {
                     Runnable {
-                        startScroll(textView)
+                        if (lyricgundonjiesu) { startScroll(textView) } else {
+                            val m0 = textView.getObjectFieldOrNull("mMarquee")
+                            m0?.apply {
+                                // 停止滚动并重置位置
+                                setFloatField("mPixelsPerMs", 0f)
+                                callMethod("stop")
+                            }
+                            startScroll(textView)
+                        }
                         runnablePool.remove(key)
                     }
                 }
@@ -172,13 +181,21 @@ object FocusNotifLyric : MusicBaseHook() {
 
     private fun startScroll(textView: TextView) {
         runCatching {
+            if (!lyricgundonjiesu) {
+                val m0 = textView.getObjectFieldOrNull("mMarquee")
+                m0?.apply {
+                    // 停止滚动并重置位置
+                    setFloatField("mPixelsPerMs", 0f)
+                    callMethod("stop")
+                }
+            }
             // 开始滚动
             textView.callMethod("setMarqueeRepeatLimit", 1)
             textView.callMethod("startMarqueeLocal")
+            lyricgundonjiesu = false
             val key = textView.hashCode()
             val m = textView.getObjectFieldOrNull("mMarquee") ?: return
             if (speed == -0.1f) {
-                // 初始化滚动速度
                 speed = m.getFloatField("mPixelsPerMs") * SPEED_INCREASE
             }
 
@@ -186,15 +203,12 @@ object FocusNotifLyric : MusicBaseHook() {
             val lineWidth = textView.layout?.getLineWidth(0)
 
             if (lineWidth != null) {
-                // 重设最大滚动宽度,只能滚动到文本结束
                 m.setFloatField("mMaxScroll", lineWidth - width)
-                // 重设速度
                 m.setFloatField("mPixelsPerMs", speed)
-                // 移除回调,防止滚动结束之后重置滚动位置
                 m.setObjectField("mRestartCallback", Choreographer.FrameCallback {})
                 // 滚动完成后清理状态
                 textView.postDelayed({
-                    XposedHelpers.setAdditionalStaticField(textView, "is_scrolling", 1)
+                    lyricgundonjiesu = true
                     runnablePool.remove(key) //移除任务引用
                 }, computeScrollDuration(lineWidth, width, speed)) // 根据速度和距离计算时长
             }
@@ -204,11 +218,9 @@ object FocusNotifLyric : MusicBaseHook() {
     }
 
     private fun computeScrollDuration(lineWidth: Float, width: Float, speed: Float): Long {
-        val maxScroll = (lineWidth - width).coerceAtLeast(0f) // 与 mMaxScroll 一致
-        val pixelsPerMs = speed // 与 mPixelsPerMs 一致
-        return if (pixelsPerMs > 0) (maxScroll / pixelsPerMs).toLong() else 0L
+        val distance = (lineWidth - width).coerceAtLeast(0f)
+        return (distance / speed).toLong()
     }
-
 
 
     override fun onStop() {


### PR DESCRIPTION
- 引入 `lyricgundonjiesu` 状态变量，用于标记歌词滚动是否已结束。
- 在更新歌词时，如果新旧歌词一致，现在会确保滚动结束并重置。
- 在 `startScroll` 调用前，如果上次滚动未结束，则先停止当前滚动并重置位置，再开始新的滚动。
- `startScroll` 内部逻辑调整：
    - 在开始滚动前，如果上次滚动未结束，会先停止并重置。
    - 开始滚动后，设置 `lyricgundonjiesu`为 `false`。
    - 滚动完成后，设置 `lyricgundonjiesu` 为 `true`。
    - 移除了 `XposedHelpers.setAdditionalStaticField(textView, "is_scrolling", 1)` 的调用。
- 简化 `computeScrollDuration` 方法，移除了对 `mMaxScroll` 和 `pixelsPerMs` 的本地变量赋值。