### PR TITLE
feat: 焦点歌词支持翻译显示

### DIFF
--- a/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
+++ b/library/common-ui/src/main/res/layout/focusaodlyric_layout.xml
@@ -33,14 +33,32 @@
         android:scaleType="centerCrop"
         tools:ignore="ContentDescription" />
 
-    <TextView
-        android:id="@id/focuslyric"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:breakStrategy="simple"
-        android:layout_marginStart="5dp"
-        android:layout_marginEnd="5dp"
-        android:maxLines="5"
-        android:textSize="18sp" />
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@id/focuslyric"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginEnd="5dp"
+            android:breakStrategy="simple"
+            android:maxLines="5"
+            android:textSize="18sp" />
+
+        <TextView
+            android:id="@+id/focustflyric"
+            android:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginEnd="5dp"
+            android:breakStrategy="simple"
+            android:maxLines="5"
+            android:textSize="18sp" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/library/common-ui/src/main/res/layout/focuslyric_layout.xml
+++ b/library/common-ui/src/main/res/layout/focuslyric_layout.xml
@@ -24,17 +24,30 @@
     android:padding="8dp"
     android:background="@android:color/transparent">
 
-    <TextView
-        android:id="@+id/focuslyric"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:breakStrategy="simple"
-        android:ellipsize="end"
-        android:layout_marginStart="5dp"
-        android:layout_marginEnd="5dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginBottom="5dp"
-        android:lineSpacingExtra="4dp"
-        android:maxLines="5"
-        android:textSize="15sp" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/focuslyric"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginEnd="5dp"
+            android:breakStrategy="simple"
+            android:maxLines="5"
+            android:textSize="18sp" />
+
+        <TextView
+            android:id="@id/focustflyric"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginEnd="5dp"
+            android:breakStrategy="simple"
+            android:maxLines="5"
+            android:textSize="18sp" />
+    </LinearLayout>
 </LinearLayout>

--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/v/FocusNotifLyric.kt
@@ -210,7 +210,6 @@ object FocusNotifLyric : MusicBaseHook() {
     }
 
 
-
     override fun onStop() {
         if (!isShowApp) cancelNotification()
     }


### PR DESCRIPTION
- 更新布局文件 `focuslyric_layout.xml` 和 `focusaodlyric_layout.xml`：
    - 新增一个 `TextView` (id: `focustflyric`) 用于显示翻译歌词。
    - 将原有歌词 `TextView` 和新增的翻译歌词 `TextView` 放置在一个垂直方向的 `LinearLayout` 中，并使其居中。
    - `focusaodlyric_layout.xml` 中，翻译歌词 `TextView` 默认设置为 `gone`。