### PR TITLE
Run init only for first application in BaseModule

### DIFF
--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/BaseModule.java
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/BaseModule.java
@@ -46,6 +46,7 @@ public abstract class BaseModule {
     }
 
     public void init(LoadPackageParam lpparam) {
+        if (!lpparam.isFirstApplication) return;
         if (swappedMap.isEmpty()) {
             swappedMap = CrashData.swappedData();
         }


### PR DESCRIPTION
Fix #1384

Added a check in BaseModule.init to ensure initialization logic runs only when lpparam.isFirstApplication is true. This prevents redundant initialization for non-primary application processes.