### PR TITLE
feat: 更新灵动岛 API 回退调用添加翻译

### DIFF
--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/pack/systemui/MusicBaseHook.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/pack/systemui/MusicBaseHook.kt
@@ -201,7 +201,7 @@ abstract class MusicBaseHook : BaseHook() {
         }.onFailure { e ->
             logE(TAG, lpparam.packageName, "send diy focus failed: ${e.message}")
             runCatching {
-                val baseinfo = FocusApi.baseinfo(basetype = 1, title = text)
+                val baseinfo = FocusApi.baseinfo(basetype = 1, title = text, content = tf)
                 val apiFallback = if (!hideAodShow) {
                     FocusApi.sendFocus(
                         addpics = iconsAdd,

--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/pack/systemui/MusicBaseHook.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/base/pack/systemui/MusicBaseHook.kt
@@ -201,7 +201,11 @@ abstract class MusicBaseHook : BaseHook() {
         }.onFailure { e ->
             logE(TAG, lpparam.packageName, "send diy focus failed: ${e.message}")
             runCatching {
-                val baseinfo = FocusApi.baseinfo(basetype = 1, title = text, content = tf)
+                val baseinfo = FocusApi.baseinfo(
+                    basetype = if (tf == null) 1 else 2,
+                    title = text,
+                    content = tf
+                )
                 val apiFallback = if (!hideAodShow) {
                     FocusApi.sendFocus(
                         addpics = iconsAdd,

--- a/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/all/SwapWiFiAndMobileNetwork.kt
+++ b/library/hook/src/main/java/com/sevtinge/hyperceiler/hook/module/hook/systemui/statusbar/icon/all/SwapWiFiAndMobileNetwork.kt
@@ -53,7 +53,7 @@ object SwapWiFiAndMobileNetwork : BaseHook() {
 
                     removedIcons.clear()
                     startIndex = if (isHyperOSVersion(3f)) {
-                        allStatusIcons.indexOf("network_speed")
+                        maxOf(allStatusIcons.indexOf("network_speed"), allStatusIcons.indexOf("hd"))
                     } else {
                         allStatusIcons.indexOf("hd")
                     }


### PR DESCRIPTION
- 在无法加载RemoteView的回退函数里的`FocusApi.baseinfo` 的调用中新增 `content` 参数显示翻译。