### PR TITLE
fix: modify proguard-rules.pro to fix annotation issue

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ fragment = "1.8.9"
 recyclerview = "1.4.0"
 
 # UI Libraries
-miuix = "1.0.10.5.1"
+miuix = "1.0.10.5.2"
 
 # Xposed & Hooks
 xposed-api = "100-1.0.3"

--- a/library/libhook/proguard-rules.pro
+++ b/library/libhook/proguard-rules.pro
@@ -29,7 +29,7 @@
     public void onPackageLoaded(...);
     public void onSystemServerLoaded(...);
 }
--keep,allowoptimization,allowobfuscation @io.github.libxposed.api.annotations.* class * {
+-keep,allowoptimization @io.github.libxposed.api.annotations.XposedHooker class * {
     @io.github.libxposed.api.annotations.BeforeInvocation <methods>;
     @io.github.libxposed.api.annotations.AfterInvocation <methods>;
 }


### PR DESCRIPTION
I'm new to this, so please ignore this PR if anything is wrong.

Issue:
- Hooks fail at runtime on JingMatrix LSPosed v1.11.0 and ReLSPosed with:
  `IllegalArgumentException: Hooker should be annotated with @XposedHooker`

What I changed:
- Remove `allowobfuscation` from the keep rule so annotation metadata is preserved
- Bump `miuix` from 1.0.10.5.1 to 1.0.10.5.2 for build

Environment:
- Xiaomi 13 Ultra HyperOS 3.0.4.0.WMACNXM (Yes I'm using xiaomi.eu ROM)
- JingMatrix/LSPosed 1.11.0 (7209)
- HyperCeiler 2.10.165-49104c4b8-r4427

[hyperceiler_logs_20260220_190710.zip](https://github.com/user-attachments/files/25438949/hyperceiler_logs_20260220_190710.zip)