### PR TITLE
refactor: 优化 `MusicBaseHook.kt` 的代码结构与作用域

### DIFF
--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SubScreenCenter.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SubScreenCenter.java
@@ -1,0 +1,18 @@
+package com.sevtinge.hyperceiler.libhook.app;
+
+
+import com.hchen.database.HookBase;
+import com.sevtinge.hyperceiler.libhook.base.BaseLoad;
+
+@HookBase(targetPackage = "com.xiaomi.subscreencenter")
+public class SubScreenCenter extends BaseLoad {
+
+    public SubScreenCenter() {
+        super(true);
+    }
+
+    @Override
+    public void onPackageLoaded() {
+//        initHook(UnlockFoucsAuth.INSTANCE, PrefsBridge.getBoolean("subscreencenter_unlock_foucs_app_sign_white_list"));
+    }
+}

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/appbase/systemui/MusicBaseHook.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/appbase/systemui/MusicBaseHook.kt
@@ -47,13 +47,13 @@ import com.hchen.superlyricapi.SuperLyricData
 import com.hchen.superlyricapi.SuperLyricTool
 import com.hyperfocus.api.FocusApi
 import com.hyperfocus.api.IslandApi
+import com.sevtinge.hyperceiler.common.log.XposedLog
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge
+import com.sevtinge.hyperceiler.common.utils.api.ProjectApi
 import com.sevtinge.hyperceiler.libhook.R
 import com.sevtinge.hyperceiler.libhook.base.BaseHook
-import com.sevtinge.hyperceiler.common.utils.api.ProjectApi
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.tool.AppsTool
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.tool.EzxHelpUtils
-import com.sevtinge.hyperceiler.libhook.utils.log.XposedLog
 import io.github.kyuubiran.ezxhelper.xposed.EzXposed
 import org.json.JSONObject
 import kotlin.math.min

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/appbase/systemui/MusicBaseHook.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/appbase/systemui/MusicBaseHook.kt
@@ -47,13 +47,13 @@ import com.hchen.superlyricapi.SuperLyricData
 import com.hchen.superlyricapi.SuperLyricTool
 import com.hyperfocus.api.FocusApi
 import com.hyperfocus.api.IslandApi
+import com.sevtinge.hyperceiler.common.utils.PrefsBridge
 import com.sevtinge.hyperceiler.libhook.R
 import com.sevtinge.hyperceiler.libhook.base.BaseHook
 import com.sevtinge.hyperceiler.common.utils.api.ProjectApi
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.tool.AppsTool
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.tool.EzxHelpUtils
-import com.sevtinge.hyperceiler.common.log.XposedLog
-import com.sevtinge.hyperceiler.common.utils.PrefsBridge
+import com.sevtinge.hyperceiler.libhook.utils.log.XposedLog
 import io.github.kyuubiran.ezxhelper.xposed.EzXposed
 import org.json.JSONObject
 import kotlin.math.min
@@ -671,66 +671,67 @@ abstract class MusicBaseHook : BaseHook() {
         }
         return tokens
     }
-}
 
-/**
- * 资源 ID 缓存
- */
-private data class ResourceIds(
-    val focuslyricLayout: Int,
-    val focuslyricIslandLayout: Int,
-    val focusaodlyricLayout: Int,
-    val focuslyricId: Int,
-    val focusiconId: Int,
-    val focustflyricId: Int
-)
-
-/**
- * 图标包
- */
-private data class IconBundle(
-    val primaryBitmap: Bitmap,
-    val icon: Icon,
-    val darkIcon: Icon,
-    val circularIcon: Icon,
-    val activityIcon: Bitmap?,
-    val hasTint: Boolean
-)
-
-/**
- * RemoteView 类型
- */
-private enum class RemoteViewType {
-    DAY, ISLAND, AOD
-}
-
-/**
- * 拆字配置
- *
- * @param maxLength 最大长度
- * @param lookahead 前瞻距离
- * @param minFraction 最小分割比例
- * @param keepSpaceInSecond 是否保留第二部分开头的空格
- * @param pairedSymbols 成对符号映射
- */
-data class SplitConfig(
-    val maxLength: Int,
-    val lookahead: Int = 2,
-    val minFraction: Double = 0.45,
-    val keepSpaceInSecond: Boolean = false,
-    val pairedSymbols: Map<Char, Char> = mapOf(
-        '(' to ')',
-        '[' to ']',
-        '{' to '}',
-        '《' to '》',
-        '"' to '"',
-        '\'' to '\'',
-        '「' to '」',
-        '『' to '』'
+    /**
+     * 资源 ID 缓存
+     */
+    private data class ResourceIds(
+        val focuslyricLayout: Int,
+        val focuslyricIslandLayout: Int,
+        val focusaodlyricLayout: Int,
+        val focuslyricId: Int,
+        val focusiconId: Int,
+        val focustflyricId: Int
     )
-)
 
-/**
- * 分词 Token
- */
-data class Token(val text: String)
+    /**
+     * 图标包
+     */
+    private data class IconBundle(
+        val primaryBitmap: Bitmap,
+        val icon: Icon,
+        val darkIcon: Icon,
+        val circularIcon: Icon,
+        val activityIcon: Bitmap?,
+        val hasTint: Boolean
+    )
+
+    /**
+     * RemoteView 类型
+     */
+    private enum class RemoteViewType {
+        DAY, ISLAND, AOD
+    }
+
+    /**
+     * 拆字配置
+     *
+     * @param maxLength 最大长度
+     * @param lookahead 前瞻距离
+     * @param minFraction 最小分割比例
+     * @param keepSpaceInSecond 是否保留第二部分开头的空格
+     * @param pairedSymbols 成对符号映射
+     */
+    data class SplitConfig(
+        val maxLength: Int,
+        val lookahead: Int = 2,
+        val minFraction: Double = 0.45,
+        val keepSpaceInSecond: Boolean = false,
+        val pairedSymbols: Map<Char, Char> = mapOf(
+            '(' to ')',
+            '[' to ']',
+            '{' to '}',
+            '《' to '》',
+            '"' to '"',
+            '\'' to '\'',
+            '「' to '」',
+            '『' to '』'
+        )
+    )
+
+    /**
+     * 分词 Token
+     */
+    data class Token(val text: String)
+
+}

--- a/library/libhook/src/main/resources/META-INF/xposed/scope.list
+++ b/library/libhook/src/main/resources/META-INF/xposed/scope.list
@@ -65,4 +65,5 @@ com.miui.voicetrigger
 com.xiaomi.simactivate.service
 miui.systemui.plugin
 com.xiaomi.xmsf
+com.xiaomi.subscreencenter
 


### PR DESCRIPTION
- **代码重构:** 将 `ResourceIds`、`IconBundle`、`RemoteViewType`、`SplitConfig` 和 `Token` 等辅助数据类和枚举移动到 `MusicBaseHook` 类内部，以收紧类成员的作用域并改善组织结构。
- **代码规范:** 调整了 `PrefsBridge` 的导入顺序，使其符合字母排序规范。