### PR TITLE
feat: 新增解除背屏应用白名单限制功能

### DIFF
--- a/library/core/src/main/res/values-zh-rCN/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rCN/strings_app.xml
@@ -465,6 +465,7 @@
     <string name="system_framework_market_use_detailmini_desc">解除应用在未使用 appClientId 的情况下跳转到小米应用商店其他应用的详情页会被拒绝展示的限制</string>
     <string name="system_framework_bypass_force_downloadui">打开下载页面时不强制使用小米下载管理器</string>
     <string name="system_framework_bypass_force_downloadui_desc">解决 Google 快速分享查看下载内容跳转错误的问题</string>
+    <string name="system_framework_fuck_subscreen_whiteList">解除背屏软件白名单</string>
     <!--核心破解-->
     <string name="system_framework_corepatch_tip">此列表下的功能需要在您了解此类功能后再选择性启用，部分选项存在一定危险性，请知悉\n常规选项的功能除总开关外均即时生效，扩展功能无论开关都需要重启才能生效</string>
     <string name="system_framework_corepatch_title">包管理服务</string>

--- a/library/core/src/main/res/values-zh-rCN/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rCN/strings_app.xml
@@ -466,6 +466,7 @@
     <string name="system_framework_bypass_force_downloadui">打开下载页面时不强制使用小米下载管理器</string>
     <string name="system_framework_bypass_force_downloadui_desc">解决 Google 快速分享查看下载内容跳转错误的问题</string>
     <string name="system_framework_fuck_subscreen_whiteList">解除背屏软件白名单</string>
+    <string name="system_framework_fuck_subscreen_not_go_to_home">禁止背屏息屏/关闭的时候返回桌面</string>
     <!--核心破解-->
     <string name="system_framework_corepatch_tip">此列表下的功能需要在您了解此类功能后再选择性启用，部分选项存在一定危险性，请知悉\n常规选项的功能除总开关外均即时生效，扩展功能无论开关都需要重启才能生效</string>
     <string name="system_framework_corepatch_title">包管理服务</string>
@@ -1705,4 +1706,5 @@
     <string name="custom_hook_mode">选择模式</string>
     <string name="open_source">开源项目</string>
     <string name="close_source">闭源项目</string>
+    <string name="subscreen">背屏</string>
 </resources>

--- a/library/core/src/main/res/values/strings_app.xml
+++ b/library/core/src/main/res/values/strings_app.xml
@@ -496,7 +496,6 @@
     <string name="system_framework_quick_screenshot_desc">Disable screenshot delay</string>
     <string name="system_framework_disable_link_turbo_toast">Hide toast of mobile network used for acceleration</string>
     <string name="system_framework_allow_third_theme">Allow to use third-party themes</string>
-    <string name="system_framework_fuck_subscreen_whiteList">Remove the subscreen app whitelist</string>
     <string name="system_framework_allow_disable_protected_package">Allows to disable protected apps</string>
     <string name="system_framework_disable_miui_watermark">Disable full screen watermark</string>
     <string name="system_framework_bypass_unknown_sources_restrictions">Allow all apps to install apps from unknown sources</string>
@@ -539,6 +538,8 @@
     <string name="system_framework_core_patch_allow_update_system_app_desc">Allow installation of system apps when updating system apps is disabled</string>
     <string name="system_framework_core_patch_unloss_fingerprint">Disable reset fingerprint</string>
     <string name="system_framework_core_patch_unloss_fingerprint_desc">May help resolve the issue of fingerprints resetting after reboot when certain package management services are enabled. Intended only for devices affected by this problem.</string>
+    <string name="system_framework_fuck_subscreen_whiteList">Remove the subscreen app whitelist</string>
+    <string name="system_framework_fuck_subscreen_not_go_to_home">Prohibit returning to the home screen when the screen is facing down, idle, or turned off</string>
     <!--Browser-->
     <string name="browser">Browser</string>
     <string name="browser_debug_mode">Unlock developer options</string>
@@ -1744,4 +1745,5 @@
     <string name="custom_hook_mode">Select mode</string>
     <string name="open_source">Open source projects</string>
     <string name="close_source">Close source projects</string>
+    <string name="subscreen">Sub Screen</string>
 </resources>

--- a/library/core/src/main/res/values/strings_app.xml
+++ b/library/core/src/main/res/values/strings_app.xml
@@ -496,6 +496,7 @@
     <string name="system_framework_quick_screenshot_desc">Disable screenshot delay</string>
     <string name="system_framework_disable_link_turbo_toast">Hide toast of mobile network used for acceleration</string>
     <string name="system_framework_allow_third_theme">Allow to use third-party themes</string>
+    <string name="system_framework_fuck_subscreen_whiteList">Remove the subscreen app whitelist</string>
     <string name="system_framework_allow_disable_protected_package">Allows to disable protected apps</string>
     <string name="system_framework_disable_miui_watermark">Disable full screen watermark</string>
     <string name="system_framework_bypass_unknown_sources_restrictions">Allow all apps to install apps from unknown sources</string>

--- a/library/core/src/main/res/xml/framework_display.xml
+++ b/library/core/src/main/res/xml/framework_display.xml
@@ -49,10 +49,19 @@
             android:title="@string/system_framework_enhance_recents_visibility"
             android:key="prefs_key_system_framework_enhance_recents_visibility" />
 
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="prefs_key_system_framework_fuck_subscreen_whiteList"
-            android:title="@string/system_framework_fuck_subscreen_whiteList" />
+
+        <PreferenceCategory android:title="@string/subscreen">
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="prefs_key_system_framework_fuck_subscreen_whiteList"
+                android:title="@string/system_framework_fuck_subscreen_whiteList" />
+
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="prefs_key_system_framework_fuck_subscreen_not_go_to_home"
+                android:title="@string/system_framework_fuck_subscreen_not_go_to_home" />
+
+        </PreferenceCategory>
 
 
     </PreferenceCategory>

--- a/library/core/src/main/res/xml/framework_display.xml
+++ b/library/core/src/main/res/xml/framework_display.xml
@@ -49,6 +49,12 @@
             android:title="@string/system_framework_enhance_recents_visibility"
             android:key="prefs_key_system_framework_enhance_recents_visibility" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_system_framework_fuck_subscreen_whiteList"
+            android:title="@string/system_framework_fuck_subscreen_whiteList" />
+
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/system_ui_display_cutout_title">

--- a/library/core/src/main/res/xml/framework_display.xml
+++ b/library/core/src/main/res/xml/framework_display.xml
@@ -49,20 +49,18 @@
             android:title="@string/system_framework_enhance_recents_visibility"
             android:key="prefs_key_system_framework_enhance_recents_visibility" />
 
+    </PreferenceCategory>
 
-        <PreferenceCategory android:title="@string/subscreen">
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="prefs_key_system_framework_fuck_subscreen_whiteList"
-                android:title="@string/system_framework_fuck_subscreen_whiteList" />
+    <PreferenceCategory android:title="@string/subscreen">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_system_framework_fuck_subscreen_whiteList"
+            android:title="@string/system_framework_fuck_subscreen_whiteList" />
 
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="prefs_key_system_framework_fuck_subscreen_not_go_to_home"
-                android:title="@string/system_framework_fuck_subscreen_not_go_to_home" />
-
-        </PreferenceCategory>
-
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_system_framework_fuck_subscreen_not_go_to_home"
+            android:title="@string/system_framework_fuck_subscreen_not_go_to_home" />
 
     </PreferenceCategory>
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SystemFramework/SystemFrameworkV.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SystemFramework/SystemFrameworkV.java
@@ -34,6 +34,7 @@ import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.AllDarkMod
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.BackgroundBlur;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.DisplayCutout;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.EnhanceRecentsVisibility;
+import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.FuckSubScreenWhiteList;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.ThemeProvider;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.display.UseAOSPScreenShot;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.freeform.AllowAutoStart;
@@ -128,6 +129,8 @@ public class SystemFrameworkV extends BaseLoad {
         initHook(UseAOSPScreenShot.INSTANCE, PrefsBridge.getBoolean("system_ui_display_use_aosp_screenshot_enable"));
         initHook(new AllDarkMode(), PrefsBridge.getBoolean("system_framework_allow_all_dark_mode"));
         initHook(new ThemeProvider(), PrefsBridge.getBoolean("system_framework_allow_third_theme"));
+        initHook(FuckSubScreenWhiteList.INSTANCE, PrefsBridge.getBoolean("system_framework_fuck_subscreen_whiteList"));
+
 
         // 其他
         initHook(new AntiQues(), PrefsBridge.getBoolean("system_settings_anti_ques"));

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
@@ -9,6 +9,11 @@ object FuckSubScreenWhiteList : BaseHook() {
 
     override fun init() {
         val asI = findClass("com.android.server.wm.ActivityStarterImpl")
+        asI.hookAllMethods("handleSubScreen") {
+            before {
+                returnConstant(false)
+            }
+        }
         asI.hookAllMethods("isShouldShowOnRearDisplay") {
             before {
                 returnConstant(true)

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
@@ -1,0 +1,21 @@
+package com.sevtinge.hyperceiler.libhook.rules.systemframework.display
+
+import com.sevtinge.hyperceiler.libhook.base.BaseHook
+import com.sevtinge.hyperceiler.libhook.utils.hookapi.tool.hookAllMethods
+
+object FuckSubScreenWhiteList : BaseHook() {
+    override fun init() {
+        val asI = findClass("com.android.server.wm.ActivityStarterImpl")
+        asI.hookAllMethods("isShouldShowOnRearDisplay") {
+            before {
+                returnConstant(true)
+            }
+        }
+        asI.hookAllMethods("isAllowedToStartOnRearDisplay") {
+            before {
+                returnConstant(true)
+            }
+        }
+
+    }
+}

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
@@ -25,7 +25,7 @@ object FuckSubScreenWhiteList : BaseHook() {
         if (notGotoHome) {
             asI.hookAllMethods("handlerTransitionFinished") {
                 before { param ->
-                    param.args[4] = false
+                    param.args[3] = false
                 }
             }
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/display/FuckSubScreenWhiteList.kt
@@ -1,9 +1,12 @@
 package com.sevtinge.hyperceiler.libhook.rules.systemframework.display
 
+import com.sevtinge.hyperceiler.common.utils.PrefsBridge
 import com.sevtinge.hyperceiler.libhook.base.BaseHook
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.tool.hookAllMethods
 
+/** 绕过背屏白名单*/
 object FuckSubScreenWhiteList : BaseHook() {
+
     override fun init() {
         val asI = findClass("com.android.server.wm.ActivityStarterImpl")
         asI.hookAllMethods("isShouldShowOnRearDisplay") {
@@ -15,6 +18,17 @@ object FuckSubScreenWhiteList : BaseHook() {
             before {
                 returnConstant(true)
             }
+        }
+        /** 禁止锁屏返回桌面 */
+        val notGotoHome = PrefsBridge.getBoolean("system_framework_fuck_subscreen_not_go_to_home")
+
+        if (notGotoHome) {
+            asI.hookAllMethods("handlerTransitionFinished") {
+                before { param ->
+                    param.args[4] = false
+                }
+            }
+
         }
 
     }


### PR DESCRIPTION
- **新增功能**: 添加了 `FuckSubScreenWhiteList` Hook 类，通过拦截 `ActivityStarterImpl` 中的 `isShouldShowOnRearDisplay` 和 `isAllowedToStartOnRearDisplay` 方法，强制返回 `true` 以解除背屏软件使用限制。
- **界面配置**:
    - 在 `framework_display.xml` 中新增了相关设置选项。
    - 补全了中英文语言资源文件（`strings_app.xml`）中的标题与描述。
- **集成**: 在 `SystemFrameworkV` 中初始化并注册了该 Hook 逻辑。