### PR TITLE
fix build: use clazz to find static field

### DIFF
--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/safecrash/CrashMonitor.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/safecrash/CrashMonitor.kt
@@ -99,7 +99,7 @@ class CrashMonitor(lpparam: XposedModuleInterface.SystemServerStartingParam) {
                     .createBeforeHook { param ->
                         val pkg = param.args[2] as? String
                         if (pkg == ProjectApi.mAppModulePkg) {
-                            val balAllowDefault = EzxHelpUtils.getStaticObjectField(param.thisObject, "BAL_ALLOW_DEFAULT")
+                            val balAllowDefault = EzxHelpUtils.getStaticObjectField(clazz, "BAL_ALLOW_DEFAULT")
                             if (balAllowDefault != null) {
                                 param.result = balAllowDefault
                             } else {


### PR DESCRIPTION
`BAL_ALLOW_DEFAULT` 实际存在于 BackgroundActivityStartController 修正位置
不慎与 #1523 混杂在了一起 添加麻烦了抱歉 （悲

![42cfa39184135d46199049e9df195275](https://github.com/user-attachments/assets/83899b92-fa27-4e2e-afd9-bb72f5c5328b)
