### PR TITLE
支持关闭电脑管家剪贴板地区校验

### DIFF
--- a/library/core/src/main/res/values-zh-rCN/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rCN/strings_app.xml
@@ -971,6 +971,8 @@
     <string name="milink_unlock_mishare">解锁小米妙享</string>
     <string name="milink_unlock_send_app">解锁全部应用流转</string>
     <string name="milink_unlock_send_app_desc">需要额外勾选 "跨屏协同服务" 作用域</string>
+    <string name="milink_disable_pc_clipboard_region_check">关闭电脑管家剪贴板地区校验</string>
+    <string name="milink_disable_pc_clipboard_region_check_desc">修复电脑管家向手机或平板同步剪贴板时，因地区不一致被互联互通服务拦截</string>
     <string name="milink_allow_camera_devices">强制支持摄像头流转</string>
     <string name="milink_fuck_hpplay">阻止生成乐播投屏相关文件</string>
     <!--录音机-->

--- a/library/core/src/main/res/values-zh-rHK/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rHK/strings_app.xml
@@ -933,6 +933,10 @@
     <!--Cast-->
     <string name="milink_hyperos">互聯互通服務</string>
     <string name="milink_unlock_mishare">解鎖小米妙享</string>
+    <string name="milink_unlock_send_app">解鎖全部應用流轉</string>
+    <string name="milink_unlock_send_app_desc">需要額外勾選「跨屏協同服務」作用域</string>
+    <string name="milink_disable_pc_clipboard_region_check">關閉電腦管家剪貼簿地區校驗</string>
+    <string name="milink_disable_pc_clipboard_region_check_desc">修復電腦管家向手機或平板同步剪貼簿時，因地區不一致被互聯互通服務攔截</string>
     <string name="milink_allow_camera_devices">強制支持攝像頭流轉</string>
     <string name="milink_fuck_hpplay">阻止生成樂播投屏相關檔案</string>
     <!--Sound Recorder-->

--- a/library/core/src/main/res/values/strings_app.xml
+++ b/library/core/src/main/res/values/strings_app.xml
@@ -1033,6 +1033,8 @@
     <string name="milink_unlock_mishare">Unlock Device interconnection</string>
     <string name="milink_unlock_send_app">Unlock all app transfers</string>
     <string name="milink_unlock_send_app_desc">Requires additionally checking the \"com.xiaomi.mirror\" scope</string>
+    <string name="milink_disable_pc_clipboard_region_check">Disable PC Manager clipboard region validation</string>
+    <string name="milink_disable_pc_clipboard_region_check_desc">Fixes PC to phone or tablet clipboard sync blocked by region mismatch</string>
     <string name="milink_allow_camera_devices">Force support for camera streaming</string>
     <string name="milink_fuck_hpplay">Block generate of hpplay folders</string>
     <!--Sound Recorder-->

--- a/library/core/src/main/res/xml/milink.xml
+++ b/library/core/src/main/res/xml/milink.xml
@@ -33,6 +33,12 @@
             android:defaultValue="false" />
 
         <SwitchPreference
+            android:summary="@string/milink_disable_pc_clipboard_region_check_desc"
+            android:title="@string/milink_disable_pc_clipboard_region_check"
+            android:key="prefs_key_milink_disable_pc_clipboard_region_check"
+            android:defaultValue="false" />
+
+        <SwitchPreference
             android:title="@string/milink_allow_camera_devices"
             android:key="prefs_key_milink_allow_camera_devices"
             android:defaultValue="false" />

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/MiLink.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/MiLink.java
@@ -22,6 +22,7 @@ import com.hchen.database.HookBase;
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge;
 import com.sevtinge.hyperceiler.libhook.base.BaseLoad;
 import com.sevtinge.hyperceiler.libhook.rules.milink.AllowCameraDevices;
+import com.sevtinge.hyperceiler.libhook.rules.milink.DisablePcManagerClipboardRegionCheck;
 import com.sevtinge.hyperceiler.libhook.rules.milink.FuckHpplay;
 import com.sevtinge.hyperceiler.libhook.rules.milink.UnlockMiShare;
 import com.sevtinge.hyperceiler.libhook.rules.milink.UnlockSendApp;
@@ -33,6 +34,7 @@ public class MiLink extends BaseLoad {
     public void onPackageLoaded() {
         initHook(new UnlockMiShare(), PrefsBridge.getBoolean("milink_unlock_mishare"));
         initHook(UnlockSendApp.INSTANCE, PrefsBridge.getBoolean("milink_unlock_send_app"));
+        initHook(new DisablePcManagerClipboardRegionCheck(), PrefsBridge.getBoolean("milink_disable_pc_clipboard_region_check"));
         initHook(new AllowCameraDevices(), PrefsBridge.getBoolean("milink_allow_camera_devices"));
         initHook(new FuckHpplay(), PrefsBridge.getBoolean("milink_fuck_hpplay"));
     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/milink/DisablePcManagerClipboardRegionCheck.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/milink/DisablePcManagerClipboardRegionCheck.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2026 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.libhook.rules.milink;
+
+import android.content.Context;
+
+import com.sevtinge.hyperceiler.common.log.XposedLog;
+import com.sevtinge.hyperceiler.libhook.base.BaseHook;
+import com.sevtinge.hyperceiler.libhook.callback.IMethodHook;
+
+public class DisablePcManagerClipboardRegionCheck extends BaseHook {
+    @Override
+    public void init() {
+        IMethodHook regionCheckHook = returnConstant(true);
+        IMethodHook regionValueHook = returnConstant("cn");
+
+        hookRegionUtils("com.xiaomi.dist.universalclipboardservice.utils.LyraUtil", regionCheckHook, regionValueHook);
+        hookRegionUtils("com.xiaomi.dist.file.service.utils.LyraUtil", regionCheckHook, regionValueHook);
+    }
+
+    private void hookRegionUtils(String className, IMethodHook regionCheckHook, IMethodHook regionValueHook) {
+        try {
+            findAndHookMethod(className, "isSameRegionWithLocal", Context.class, String.class, regionCheckHook);
+            XposedLog.i(TAG, getPackageName(), "Hooked " + className + "#isSameRegionWithLocal");
+        } catch (Throwable t) {
+            XposedLog.w(TAG, getPackageName(), "Failed to hook " + className + "#isSameRegionWithLocal", t);
+        }
+
+        try {
+            findAndHookMethod(className, "getDeviceRegion", Context.class, String.class, regionValueHook);
+            XposedLog.i(TAG, getPackageName(), "Hooked " + className + "#getDeviceRegion");
+        } catch (Throwable t) {
+            XposedLog.w(TAG, getPackageName(), "Failed to hook " + className + "#getDeviceRegion", t);
+        }
+    }
+}


### PR DESCRIPTION
`5.8.0.14` 的小米电脑管家会取 `HKEY_CURRENT_USER\Control Panel\International\Geo` 下的 `name` (Windows   国家/地区设置) 作为 `region`

而在剪贴板同步时设备互联的 `universalclipboardservice` 会检查 `targetRegion` 与当前设备的 `localRegion` 是否一致，如果 Windows 的国家/地区设置被修改为了其它地区（比如我为了使用 Xbox XGP 修改为了 hk），就会丢弃同步过来的剪贴板文本

会造成 Windows 设置的区域不一致的用户
- 从手机/平板复制文本能正常同步到 PC 
-  PC 复制文本时无法同步到手机/平板