### PR TITLE
framework: keep super-island Focus notification across swipe-up-clean

### DIFF
--- a/library/core/src/main/res/values-zh-rCN/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rCN/strings_app.xml
@@ -435,8 +435,8 @@
     <string name="system_other_flag_secure_desc">允许对任意应用进行截屏和录屏</string>
     <string name="system_other_delete_on_post_notification">移除上层显示通知</string>
     <string name="system_other_delete_on_post_notification_desc">移除 \"此应用正显示在屏幕上其他应用的上层\" 通知</string>
-    <string name="system_framework_keep_focus_on_swipe">划掉应用后保留超级岛</string>
-    <string name="system_framework_keep_focus_on_swipe_desc">阻止 HyperOS 在从最近任务划掉应用时清除正在进行的 Focus 通知（外卖、打车、共享单车、导航等），让超级岛保留。普通通知、手动强行停止不受影响。</string>
+    <string name="system_framework_keep_focus_on_swipe">保留正在进行的超级岛</string>
+    <string name="system_framework_keep_focus_on_swipe_desc">划掉应用或其通知组时，保留正在进行的 Focus 通知（外卖、打车等）。</string>
     <string name="system_framework_share_menu_test">分享菜单测试</string>
     <string name="system_framework_open_with_menu_test">打开方式菜单测试</string>
     <string name="system_framework_other_speed_install">快速安装</string>

--- a/library/core/src/main/res/values-zh-rCN/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rCN/strings_app.xml
@@ -435,6 +435,8 @@
     <string name="system_other_flag_secure_desc">允许对任意应用进行截屏和录屏</string>
     <string name="system_other_delete_on_post_notification">移除上层显示通知</string>
     <string name="system_other_delete_on_post_notification_desc">移除 \"此应用正显示在屏幕上其他应用的上层\" 通知</string>
+    <string name="system_framework_keep_focus_on_swipe">划掉应用后保留超级岛</string>
+    <string name="system_framework_keep_focus_on_swipe_desc">阻止 HyperOS 在从最近任务划掉应用时清除正在进行的 Focus 通知（外卖、打车、共享单车、导航等），让超级岛保留。普通通知、手动强行停止不受影响。</string>
     <string name="system_framework_share_menu_test">分享菜单测试</string>
     <string name="system_framework_open_with_menu_test">打开方式菜单测试</string>
     <string name="system_framework_other_speed_install">快速安装</string>

--- a/library/core/src/main/res/values/strings_app.xml
+++ b/library/core/src/main/res/values/strings_app.xml
@@ -475,8 +475,8 @@
     <string name="system_other_flag_secure_desc">Allows screenshots and screen recordings of any app</string>
     <string name="system_other_delete_on_post_notification">Remove pop-up windows notification</string>
     <string name="system_other_delete_on_post_notification_desc">Remove \"This app is displaying over other apps\" notification</string>
-    <string name="system_framework_keep_focus_on_swipe">Keep Super Island after swiping the app away</string>
-    <string name="system_framework_keep_focus_on_swipe_desc">Stops MIUI from clearing in-progress Focus notifications (food delivery, ride-hailing, shared bikes, navigation, etc.) when you swipe the app from recents. Other notifications and manual Force Stop are not affected.</string>
+    <string name="system_framework_keep_focus_on_swipe">Keep Super Island alive</string>
+    <string name="system_framework_keep_focus_on_swipe_desc">Preserves in-progress Focus notifications (food delivery, ride, etc.) when swiping the app or its notification group away.</string>
     <string name="system_framework_share_menu_test">Share menu test</string>
     <string name="system_framework_open_with_menu_test">Open with menu test</string>
     <string name="system_framework_other_speed_install">Speed install</string>

--- a/library/core/src/main/res/values/strings_app.xml
+++ b/library/core/src/main/res/values/strings_app.xml
@@ -475,6 +475,8 @@
     <string name="system_other_flag_secure_desc">Allows screenshots and screen recordings of any app</string>
     <string name="system_other_delete_on_post_notification">Remove pop-up windows notification</string>
     <string name="system_other_delete_on_post_notification_desc">Remove \"This app is displaying over other apps\" notification</string>
+    <string name="system_framework_keep_focus_on_swipe">Keep Super Island after swiping the app away</string>
+    <string name="system_framework_keep_focus_on_swipe_desc">Stops MIUI from clearing in-progress Focus notifications (food delivery, ride-hailing, shared bikes, navigation, etc.) when you swipe the app from recents. Other notifications and manual Force Stop are not affected.</string>
     <string name="system_framework_share_menu_test">Share menu test</string>
     <string name="system_framework_open_with_menu_test">Open with menu test</string>
     <string name="system_framework_other_speed_install">Speed install</string>

--- a/library/core/src/main/res/xml/framework_other.xml
+++ b/library/core/src/main/res/xml/framework_other.xml
@@ -116,6 +116,12 @@
             android:summary="@string/system_other_delete_on_post_notification_desc"
             android:title="@string/system_other_delete_on_post_notification" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_system_framework_keep_focus_on_swipe"
+            android:summary="@string/system_framework_keep_focus_on_swipe_desc"
+            android:title="@string/system_framework_keep_focus_on_swipe" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/system_framework_core_title">

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SystemFramework/SystemFrameworkB.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SystemFramework/SystemFrameworkB.java
@@ -72,6 +72,7 @@ import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.DisableVeri
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.EffectBinderProxy;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.GMSDozeFixFramework;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.HookEntry;
+import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.KeepFocusOnSwipe;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.LinkTurboToast;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.NativeFilePicker;
 import com.sevtinge.hyperceiler.libhook.rules.systemframework.others.NoAccessDeviceLogsRequest;
@@ -146,6 +147,7 @@ public class SystemFrameworkB extends BaseLoad {
         initHook(new LinkTurboToast(), PrefsBridge.getBoolean("system_framework_disable_link_turbo_toast"));
         initHook(new AllowUntrustedTouchForU(), PrefsBridge.getBoolean("system_framework_allow_untrusted_touch"));
         initHook(DeleteOnPostNotification.INSTANCE, PrefsBridge.getBoolean("system_other_delete_on_post_notification"));
+        initHook(new KeepFocusOnSwipe(), PrefsBridge.getBoolean("system_framework_keep_focus_on_swipe"));
         initHook(new SystemLockApp(), PrefsBridge.getBoolean("system_framework_guided_access"));
         initHook(new AllowManageAllNotifications(), PrefsBridge.getBoolean("system_framework_allow_manage_all_notifications"));
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/KeepFocusOnSwipe.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/KeepFocusOnSwipe.java
@@ -1,0 +1,204 @@
+/*
+ * This file is part of HyperCeiler.
+ *
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2023-2026 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.libhook.rules.systemframework.others;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.service.notification.StatusBarNotification;
+import android.text.TextUtils;
+
+import com.sevtinge.hyperceiler.libhook.base.BaseHook;
+import com.sevtinge.hyperceiler.libhook.callback.IMethodHook;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.github.kyuubiran.ezxhelper.xposed.common.HookParam;
+
+/**
+ * 修复 HyperOS 3 超级岛：划掉外卖/打车/共享单车等 App 后，正在进行的 Focus 通知
+ * 不应该被 PACKAGE_RESTARTED 路径误清掉。
+ * <p>
+ * 双 Hook 设计：
+ * <ol>
+ *     <li><b>ProcessCleanerBase.tryToForceStopPackage</b>：MIUI 划掉最近任务最终
+ *         会以 reason=&quot;SwipeUpClean&quot; 调到这里。命中时给目标 pkg 打一个 15s TTL
+ *         的短期标记。</li>
+ *     <li><b>NotificationManagerServiceImpl.skipClearAll</b>：当 reason==5
+ *         （PACKAGE_RESTARTED）且 pkg 命中刚才的标记，且通知是「可更新 Focus」
+ *         （在 Settings.Secure[&quot;updatable_focus_notifs&quot;] 里，或带 miui.focus.param
+ *         且 updatable=true / scene 是 foodDelivery/carHailing）时，强制返回 true，
+ *         让通知保留，超级岛随之保留。</li>
+ * </ol>
+ * 普通强停、通知栏手动滑掉、普通营销通知都不会被影响。
+ */
+public class KeepFocusOnSwipe extends BaseHook {
+
+    private static final String SWIPE_UP_CLEAN = "SwipeUpClean";
+    private static final int REASON_PACKAGE_CHANGED = 5;
+    private static final long MARK_TTL_MILLIS = 15_000L;
+
+    private static final String EXTRA_FOCUS_PARAM = "miui.focus.param";
+    private static final String SCENE_FOOD_DELIVERY = "foodDelivery";
+    private static final String SCENE_CAR_HAILING = "carHailing";
+
+    /** pkg -> mark timestamp (ms). Shared between the two hooks. */
+    private static final ConcurrentHashMap<String, Long> SWIPE_MARKS = new ConcurrentHashMap<>();
+
+    @Override
+    public void init() {
+        hookSwipeMarker();
+        hookSkipClearAll();
+    }
+
+    private void hookSwipeMarker() {
+        findAndHookMethod(
+            "com.android.server.am.ProcessCleanerBase",
+            "tryToForceStopPackage",
+            String.class, int.class, String.class,
+            new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    Object reasonObj = param.getArgs()[2];
+                    if (!(reasonObj instanceof String)) return;
+                    String reason = (String) reasonObj;
+                    // getKillReason(policy=10) may append a suffix to the base string.
+                    if (!reason.startsWith(SWIPE_UP_CLEAN)) return;
+
+                    Object pkgObj = param.getArgs()[0];
+                    if (!(pkgObj instanceof String)) return;
+                    SWIPE_MARKS.put((String) pkgObj, System.currentTimeMillis());
+                }
+            }
+        );
+    }
+
+    private void hookSkipClearAll() {
+        Class<?> recordCls = findClassIfExists("com.android.server.notification.NotificationRecord");
+        if (recordCls == null) return;
+
+        findAndHookMethod(
+            "com.android.server.notification.NotificationManagerServiceImpl",
+            "skipClearAll",
+            recordCls, int.class,
+            new IMethodHook() {
+                @Override
+                public void after(HookParam param) {
+                    if (Boolean.TRUE.equals(param.getResult())) return;
+
+                    Object reasonObj = param.getArgs()[1];
+                    if (!(reasonObj instanceof Integer)) return;
+                    if ((Integer) reasonObj != REASON_PACKAGE_CHANGED) return;
+
+                    Object record = param.getArgs()[0];
+                    if (record == null) return;
+
+                    StatusBarNotification sbn;
+                    String key;
+                    try {
+                        sbn = (StatusBarNotification) callMethod(record, "getSbn");
+                        key = (String) callMethod(record, "getKey");
+                    } catch (Throwable ignored) {
+                        return;
+                    }
+                    if (sbn == null || key == null) return;
+
+                    if (!isMarkedRecently(sbn.getPackageName())) return;
+                    if (!isUpdatableFocusNotification(sbn, key)) return;
+
+                    param.setResult(true);
+                }
+            }
+        );
+    }
+
+    private static boolean isMarkedRecently(String pkg) {
+        if (pkg == null) return false;
+        Long t = SWIPE_MARKS.get(pkg);
+        if (t == null) return false;
+        if (System.currentTimeMillis() - t > MARK_TTL_MILLIS) {
+            SWIPE_MARKS.remove(pkg);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Mirrors HyperOS's own {@code FocusTemplate} definition:
+     * <pre>
+     * updatable = (param["updatable"] == true
+     *              || scene == foodDelivery
+     *              || scene == carHailing)
+     *             && hasPermission()
+     * </pre>
+     * The secure-setting check is the authoritative path because SystemUI's
+     * {@code FocusCoordinator} writes the system-accepted set there; the param
+     * check is a fallback for the small window where the setting hasn't been
+     * refreshed yet.
+     */
+    private static boolean isUpdatableFocusNotification(StatusBarNotification sbn, String key) {
+        if (isKeyInUpdatableFocusNotifs(key)) return true;
+        return looksLikeUpdatableFocusParam(sbn);
+    }
+
+    private static boolean isKeyInUpdatableFocusNotifs(String key) {
+        try {
+            Context ctx = getSystemContext();
+            if (ctx == null) return false;
+            String raw = Settings.Secure.getString(ctx.getContentResolver(), "updatable_focus_notifs");
+            if (TextUtils.isEmpty(raw)) return false;
+            JSONArray arr = new JSONArray(raw);
+            for (int i = 0; i < arr.length(); i++) {
+                if (TextUtils.equals(key, arr.optString(i, ""))) return true;
+            }
+        } catch (Throwable ignored) {
+        }
+        return false;
+    }
+
+    private static boolean looksLikeUpdatableFocusParam(StatusBarNotification sbn) {
+        try {
+            if (sbn.getNotification() == null) return false;
+            Bundle extras = sbn.getNotification().extras;
+            if (extras == null) return false;
+            String paramJson = extras.getString(EXTRA_FOCUS_PARAM);
+            if (TextUtils.isEmpty(paramJson)) return false;
+            JSONObject obj = new JSONObject(paramJson);
+            if (obj.optBoolean("updatable", false)) return true;
+            String scene = obj.optString("scene", "");
+            return SCENE_FOOD_DELIVERY.equals(scene) || SCENE_CAR_HAILING.equals(scene);
+        } catch (Throwable ignored) {
+        }
+        return false;
+    }
+
+    private static Context getSystemContext() {
+        try {
+            Class<?> atCls = Class.forName("android.app.ActivityThread");
+            Object at = atCls.getMethod("currentActivityThread").invoke(null);
+            if (at == null) return null;
+            return (Context) atCls.getMethod("getSystemContext").invoke(at);
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+}

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/KeepFocusOnSwipe.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/KeepFocusOnSwipe.java
@@ -40,28 +40,31 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.github.kyuubiran.ezxhelper.xposed.common.HookParam;
 
 /**
- * 修复 HyperOS 3 超级岛：划掉外卖/打车/共享单车等 App 后，正在进行的 Focus 通知
- * 不应该被 PACKAGE_RESTARTED 广播触发的清理路径误清掉。
- * <p>
- * 双 Hook 设计：
+ * 阻止 HyperOS 3 在两条系统级路径上误清正在进行的 Focus 通知（让超级岛保留）：
  * <ol>
- *     <li><b>ProcessCleanerBase.tryToForceStopPackage</b>：MIUI 划掉最近任务最终
- *         会以 reason=&quot;SwipeUpClean&quot; 调到这里。命中时给目标 pkg 打一个 15s TTL
- *         的短期标记。</li>
- *     <li><b>NotificationManagerServiceImpl.skipClearAll</b>：当
- *         reason == {@link android.service.notification.NotificationListenerService#REASON_PACKAGE_CHANGED}
- *         (5，由 ACTION_PACKAGE_RESTARTED 广播触发) 且 pkg 命中刚才的标记，
- *         且通知是「可更新 Focus」（在 Settings.Secure[&quot;updatable_focus_notifs&quot;]
- *         里，或带 miui.focus.param 且 updatable=true / scene 是 foodDelivery/carHailing）
- *         时，强制返回 true，让通知保留，超级岛随之保留。</li>
+ *     <li><b>划掉最近任务</b> ── MIUI 走 ProcessCleanerBase.tryToForceStopPackage
+ *         (reason=&quot;SwipeUpClean&quot;) → forceStopPackage → PACKAGE_RESTARTED 广播 →
+ *         NotificationManagerService.cancelAllNotificationsInt(reason=5)。
+ *         我们在 tryToForceStopPackage 打 15s TTL 的 pkg 标记，再在
+ *         NotificationManagerServiceImpl.skipClearAll(reason=5) 命中标记 + 可更新
+ *         Focus 时强制返回 true。</li>
+ *     <li><b>划掉自动分组的通知组</b> ── 用户在通知栏整体划掉某 App 的非 Focus
+ *         通知组时，NotificationManagerService 走 cancelGroupChildrenByListLocked
+ *         → cancelNotificationLocked(reason=12) 循环取消。MIUI 的 skipClearAll
+ *         只覆盖批量入口，不覆盖这里。我们直接 hook
+ *         NotificationManagerService.cancelNotificationLocked，对可更新 Focus 通知
+ *         在 reason=12 时阻止取消。</li>
  * </ol>
- * 普通强停、通知栏手动滑掉、普通营销通知都不会被影响。
+ * 不影响：手动强停、通知栏手动单独划掉 Focus 通知本身、外卖 App 主动 cancel
+ * 订单通知、普通营销通知。
  */
 public class KeepFocusOnSwipe extends BaseHook {
 
     private static final String SWIPE_UP_CLEAN = "SwipeUpClean";
     /** Matches {@code NotificationListenerService.REASON_PACKAGE_CHANGED}. */
     private static final int REASON_PACKAGE_CHANGED = 5;
+    /** Matches {@code NotificationListenerService.REASON_GROUP_SUMMARY_CANCELED}. */
+    private static final int REASON_GROUP_SUMMARY_CANCELED = 12;
     private static final long MARK_TTL_MILLIS = 15_000L;
 
     private static final String EXTRA_FOCUS_PARAM = "miui.focus.param";
@@ -84,6 +87,7 @@ public class KeepFocusOnSwipe extends BaseHook {
     public void init() {
         hookSwipeMarker();
         hookSkipClearAll();
+        hookGroupChildCancel();
     }
 
     private void hookSwipeMarker() {
@@ -160,6 +164,58 @@ public class KeepFocusOnSwipe extends BaseHook {
                     if (!isUpdatableFocusNotification(sbn, key)) return;
 
                     param.setResult(true);
+                }
+            }
+        );
+    }
+
+    /**
+     * Hook NotificationManagerService.cancelNotificationLocked (8-arg overload, the real
+     * implementation; the 6-arg shim delegates to it). When a non-Focus notification group
+     * is dismissed, NMS calls cancelGroupChildrenByListLocked which removes each child from
+     * the in-memory maps and then invokes this method with reason=12 to broadcast the
+     * removal. If any of those children happens to be an updatable Focus (e.g. MIUI auto-
+     * grouped the delivery notif with the app's other notifs), the broadcast tears down
+     * the super-island. Returning early here suppresses the broadcast — SystemUI never
+     * sees the removal so the island stays. The next focus update from the App re-enqueues
+     * normally and restores NMS state.
+     * <p>
+     * Unlike the swipe-clean path, no SwipeMarker check: this is a per-record decision
+     * driven by reason + record content, not by who triggered the cancel.
+     */
+    private void hookGroupChildCancel() {
+        Class<?> recordCls = findClassIfExists("com.android.server.notification.NotificationRecord");
+        if (recordCls == null) return;
+
+        findAndHookMethod(
+            "com.android.server.notification.NotificationManagerService",
+            "cancelNotificationLocked",
+            recordCls, boolean.class, int.class, int.class, int.class,
+            boolean.class, String.class, long.class,
+            new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    Object reasonObj = param.getArgs()[2];
+                    if (!(reasonObj instanceof Integer)) return;
+                    if ((Integer) reasonObj != REASON_GROUP_SUMMARY_CANCELED) return;
+
+                    Object record = param.getArgs()[0];
+                    if (record == null) return;
+
+                    StatusBarNotification sbn;
+                    String key;
+                    try {
+                        sbn = (StatusBarNotification) callMethod(record, "getSbn");
+                        key = (String) callMethod(record, "getKey");
+                    } catch (Throwable ignored) {
+                        return;
+                    }
+                    if (sbn == null || key == null) return;
+
+                    if (!isUpdatableFocusNotification(sbn, key)) return;
+
+                    // void method — suppress the cancel by short-circuiting.
+                    param.setResult(null);
                 }
             }
         );

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/KeepFocusOnSwipe.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/KeepFocusOnSwipe.java
@@ -30,30 +30,37 @@ import com.sevtinge.hyperceiler.libhook.callback.IMethodHook;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.github.kyuubiran.ezxhelper.xposed.common.HookParam;
 
 /**
  * 修复 HyperOS 3 超级岛：划掉外卖/打车/共享单车等 App 后，正在进行的 Focus 通知
- * 不应该被 PACKAGE_RESTARTED 路径误清掉。
+ * 不应该被 PACKAGE_RESTARTED 广播触发的清理路径误清掉。
  * <p>
  * 双 Hook 设计：
  * <ol>
  *     <li><b>ProcessCleanerBase.tryToForceStopPackage</b>：MIUI 划掉最近任务最终
  *         会以 reason=&quot;SwipeUpClean&quot; 调到这里。命中时给目标 pkg 打一个 15s TTL
  *         的短期标记。</li>
- *     <li><b>NotificationManagerServiceImpl.skipClearAll</b>：当 reason==5
- *         （PACKAGE_RESTARTED）且 pkg 命中刚才的标记，且通知是「可更新 Focus」
- *         （在 Settings.Secure[&quot;updatable_focus_notifs&quot;] 里，或带 miui.focus.param
- *         且 updatable=true / scene 是 foodDelivery/carHailing）时，强制返回 true，
- *         让通知保留，超级岛随之保留。</li>
+ *     <li><b>NotificationManagerServiceImpl.skipClearAll</b>：当
+ *         reason == {@link android.service.notification.NotificationListenerService#REASON_PACKAGE_CHANGED}
+ *         (5，由 ACTION_PACKAGE_RESTARTED 广播触发) 且 pkg 命中刚才的标记，
+ *         且通知是「可更新 Focus」（在 Settings.Secure[&quot;updatable_focus_notifs&quot;]
+ *         里，或带 miui.focus.param 且 updatable=true / scene 是 foodDelivery/carHailing）
+ *         时，强制返回 true，让通知保留，超级岛随之保留。</li>
  * </ol>
  * 普通强停、通知栏手动滑掉、普通营销通知都不会被影响。
  */
 public class KeepFocusOnSwipe extends BaseHook {
 
     private static final String SWIPE_UP_CLEAN = "SwipeUpClean";
+    /** Matches {@code NotificationListenerService.REASON_PACKAGE_CHANGED}. */
     private static final int REASON_PACKAGE_CHANGED = 5;
     private static final long MARK_TTL_MILLIS = 15_000L;
 
@@ -63,6 +70,15 @@ public class KeepFocusOnSwipe extends BaseHook {
 
     /** pkg -> mark timestamp (ms). Shared between the two hooks. */
     private static final ConcurrentHashMap<String, Long> SWIPE_MARKS = new ConcurrentHashMap<>();
+
+    /**
+     * Memoizes the parsed Settings.Secure["updatable_focus_notifs"] JSON so that
+     * a single cleanup burst (many notifications for one pkg processed in a row)
+     * does not re-read the setting and re-parse the JSON for every record.
+     * Volatile because writes happen on the binder thread serving skipClearAll.
+     */
+    private static volatile String sLastRawFocusNotifs;
+    private static volatile Set<String> sLastParsedFocusNotifs;
 
     @Override
     public void init() {
@@ -86,10 +102,28 @@ public class KeepFocusOnSwipe extends BaseHook {
 
                     Object pkgObj = param.getArgs()[0];
                     if (!(pkgObj instanceof String)) return;
-                    SWIPE_MARKS.put((String) pkgObj, System.currentTimeMillis());
+                    long now = System.currentTimeMillis();
+                    pruneExpiredMarks(now);
+                    SWIPE_MARKS.put((String) pkgObj, now);
                 }
             }
         );
+    }
+
+    /**
+     * Opportunistically drop entries whose TTL has elapsed. Called from
+     * {@code tryToForceStopPackage} hook (the only writer), so even if a marked
+     * package never triggers a follow-up {@code skipClearAll} check, the map
+     * stays bounded by the number of swipe-up-cleans inside one TTL window.
+     */
+    private static void pruneExpiredMarks(long now) {
+        Iterator<Map.Entry<String, Long>> it = SWIPE_MARKS.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Long> e = it.next();
+            if (now - e.getValue() > MARK_TTL_MILLIS) {
+                it.remove();
+            }
+        }
     }
 
     private void hookSkipClearAll() {
@@ -166,13 +200,38 @@ public class KeepFocusOnSwipe extends BaseHook {
             if (ctx == null) return false;
             String raw = Settings.Secure.getString(ctx.getContentResolver(), "updatable_focus_notifs");
             if (TextUtils.isEmpty(raw)) return false;
-            JSONArray arr = new JSONArray(raw);
-            for (int i = 0; i < arr.length(); i++) {
-                if (TextUtils.equals(key, arr.optString(i, ""))) return true;
-            }
+            Set<String> parsed = parsedFocusNotifs(raw);
+            return parsed.contains(key);
         } catch (Throwable ignored) {
         }
         return false;
+    }
+
+    private static Set<String> parsedFocusNotifs(String raw) {
+        // Fast path: same raw payload as last time -> reuse parsed Set.
+        // Compared by equals() to tolerate identical reissues from Settings.
+        Set<String> cached = sLastParsedFocusNotifs;
+        if (cached != null && raw.equals(sLastRawFocusNotifs)) {
+            return cached;
+        }
+        Set<String> parsed = parseFocusNotifsArray(raw);
+        sLastRawFocusNotifs = raw;
+        sLastParsedFocusNotifs = parsed;
+        return parsed;
+    }
+
+    private static Set<String> parseFocusNotifsArray(String raw) {
+        Set<String> set = new LinkedHashSet<>();
+        try {
+            JSONArray arr = new JSONArray(raw);
+            for (int i = 0; i < arr.length(); i++) {
+                String k = arr.optString(i, "");
+                if (!k.isEmpty()) set.add(k);
+            }
+        } catch (Throwable ignored) {
+            return Collections.emptySet();
+        }
+        return set;
     }
 
     private static boolean looksLikeUpdatableFocusParam(StatusBarNotification sbn) {


### PR DESCRIPTION
## 背景

HyperOS 3 上有这样一个具体现象：外卖订单上了超级岛之后，如果用户从最近任务里把外卖 App 划掉，岛会立刻消失，即使订单还在配送中。打车、共享单车（哈啰/美团/青桔）、第三方导航、健身轨迹等任何走系统 Focus / Live API 的实时状态都有同样问题。

## 根因

最近任务划掉 App 在 MIUI 路径上会走 force-stop 触发 PACKAGE_RESTARTED：

```
RecentsContainer.killProcess
  → ProcessManagerWrapper.doSwapUPClean (policy=7)
  → ProcessSceneCleaner.handleSwipeKill
  → ProcessCleanerBase.killOnce(level=104)
  → ProcessCleanerBase.tryToForceStopPackage(pkg, userId, ""SwipeUpClean"")
  → ActivityManagerInternal.forceStopPackage
  → 广播 PACKAGE_RESTARTED
  → NotificationManagerService.cancelAllNotificationsInt(..., reason=5)
  → NotificationManagerServiceStub.skipClearAll(record, 5)   ← 返回 false
  → 外卖通知被清掉
  → SystemUI FocusNotificationController.onNotificationRemoved
  → DynamicIslandWindowViewController.removeDynamicIslandView
  → 超级岛消失
```

HyperOS 自身在 `NotificationManagerServiceImpl.skipClearAll` 里已经给可更新 Focus 通知做了清除豁免，但只覆盖 `reason 3 / 9 / 11`，**没覆盖 reason 5（PACKAGE_RESTARTED）**。这是系统侧设计断点。

## 修复方式

新增 `KeepFocusOnSwipe`，在 `system_server` 里加两个 hook：

1. **`ProcessCleanerBase.tryToForceStopPackage`** — reason 以 `"SwipeUpClean"` 开头时给目标 pkg 打一个 15s TTL 的短期标记，把"最近任务划掉"和"手动强停 / 应用崩溃"等其他 force-stop 来源区分开。

2. **`NotificationManagerServiceImpl.skipClearAll`** — 当 `reason == 5`、pkg 命中刚才的标记、且 record 是可更新 Focus 通知时，强制 `setResult(true)`。

「可更新 Focus 通知」的判定完全镜像 HyperOS 自己在 `miui.systemui.notification.focus.template.FocusTemplate` 里的 gate：

```java
updatable = (param.optBoolean(""updatable"", false)
              || scene == FOOD_DELIVERY
              || scene == CAR_HAILING)
            && hasPermission();
```

主判定查 `Settings.Secure[""updatable_focus_notifs""]`（SystemUI 的 `FocusCoordinator` 把所有被系统接受为可更新的 Focus key 都同步在这里）；兜底直接读 `miui.focus.param` JSON，避免 secure setting 有刷新延迟时漏判。

## 不会影响的场景

- 用户在通知栏手动划掉通知：不经过 `skipClearAll`，照旧消失
- 用户在「设置 → 应用 → 强行停止」强停 App：没有 SwipeUpClean 标记
- 同一个 App 的普通营销/活动通知：没有 `miui.focus.param`，照旧清除
- 普通 Android `setLiveUpdate` / `promoted ongoing`：不带 `miui.focus.param` 且依赖 App 自身后台更新 `RemoteViews`，划掉后保留无意义
- 一次性 Focus 场景（`verifyCode` / `timer` / `smartHomeAlert` 等没声明 `updatable` 的）

## UI

新增开关：**系统框架 → 其他 → 显示与通知 → 划掉应用后保留超级岛**（紧邻已有的"移除上层显示通知"）。中英文都加了，默认关。

## 测试环境

- 设备：Xiaomi `pudding`
- 系统：`OS3.0.309.0.WPCCNXM`（HyperOS 3 / Android 16 / SDK 36）
- 框架：LSPosed

签名核对依据均来自该设备 pull 出来的 `miui-services.jar` / `services.jar` / `MIUISystemUIPlugin.apk`，与代码里的反射查找一致。

## 选项分类

`@HookBase(targetPackage = ""system"", minSdk = 36)` —— 跟同文件其他 reason-5/通知相关 hook 一致，挂在 `SystemFrameworkB`。