### PR TITLE
soundrecorder: mark AI transcription as a standard progress notification

### DIFF
--- a/library/core/src/main/res/values-zh-rCN/strings_app.xml
+++ b/library/core/src/main/res/values-zh-rCN/strings_app.xml
@@ -1014,6 +1014,8 @@
     <string name="sound_recorder">录音机</string>
     <string name="sound_recorder_disable_ai_watermark">禁用水印</string>
     <string name="sound_recorder_unlock_recording_scene">解锁选择录音场景</string>
+    <string name="sound_recorder_mark_transcribe_progress">录音转写改为标准进度通知</string>
+    <string name="sound_recorder_mark_transcribe_progress_desc">补上标准进度条与持续状态标识，解决转写过程被小米运动健康等通知监听 App 每 1% 重复推送到手环/手表的问题。</string>
     <!--笔记-->
     <string name="notes">笔记</string>
     <string name="notes_disable_ai_watermark">禁用水印</string>

--- a/library/core/src/main/res/values/strings_app.xml
+++ b/library/core/src/main/res/values/strings_app.xml
@@ -1061,6 +1061,8 @@
     <string name="sound_recorder">Sound Recorder</string>
     <string name="sound_recorder_disable_ai_watermark">Disable AI watermark</string>
     <string name="sound_recorder_unlock_recording_scene">Unlock the recording scene</string>
+    <string name="sound_recorder_mark_transcribe_progress">Use standard progress notification for transcription</string>
+    <string name="sound_recorder_mark_transcribe_progress_desc">Adds standard progress + ongoing flags so listeners (Mi Fitness wearable sync, etc.) stop forwarding every 1% update to the watch as a brand-new alert.</string>
     <!--Notes-->
     <string name="notes">Notes</string>
     <string name="notes_disable_ai_watermark">Disable AI watermark</string>

--- a/library/core/src/main/res/xml/soundrecorder.xml
+++ b/library/core/src/main/res/xml/soundrecorder.xml
@@ -36,6 +36,12 @@
             android:key="prefs_key_sound_recorder_unlock_ai"
             android:title="@string/unlock_ai" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="prefs_key_sound_recorder_mark_transcribe_progress"
+            android:summary="@string/sound_recorder_mark_transcribe_progress_desc"
+            android:title="@string/sound_recorder_mark_transcribe_progress" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SoundRecorder.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SoundRecorder.java
@@ -23,6 +23,7 @@ import com.hchen.database.HookBase;
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge;
 import com.sevtinge.hyperceiler.libhook.base.BaseLoad;
 import com.sevtinge.hyperceiler.libhook.rules.soundrecorder.DisableAiWatermark;
+import com.sevtinge.hyperceiler.libhook.rules.soundrecorder.MarkTranscribeProgress;
 import com.sevtinge.hyperceiler.libhook.rules.soundrecorder.UnlockAIMode;
 import com.sevtinge.hyperceiler.libhook.rules.soundrecorder.UnlockRecordingScene;
 
@@ -33,5 +34,6 @@ public class SoundRecorder extends BaseLoad {
         initHook(new DisableAiWatermark(), PrefsBridge.getBoolean("sound_recorder_disable_ai_watermark"));
         initHook(UnlockRecordingScene.INSTANCE, PrefsBridge.getBoolean("sound_recorder_unlock_recording_scene"));
         initHook(UnlockAIMode.INSTANCE, PrefsBridge.getBoolean("sound_recorder_unlock_ai"));
+        initHook(new MarkTranscribeProgress(), PrefsBridge.getBoolean("sound_recorder_mark_transcribe_progress"));
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/soundrecorder/MarkTranscribeProgress.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/soundrecorder/MarkTranscribeProgress.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of HyperCeiler.
+ *
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2023-2026 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.libhook.rules.soundrecorder;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.os.Bundle;
+
+import com.sevtinge.hyperceiler.libhook.base.BaseHook;
+import com.sevtinge.hyperceiler.libhook.callback.IMethodHook;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.github.kyuubiran.ezxhelper.xposed.common.HookParam;
+
+/**
+ * 录音机 AI 转写进度通知 (channel_id_record_recognition / id=1001) 把进度写在
+ * 标题里 (例: &quot;AI转写中 12%&quot;)，但没有调用 setProgress() 也没有 setOngoing()，
+ * 导致通知监听类应用 (小米运动健康、各类手环同步) 把每次 1% 变化都当成新通知
+ * 反复推送/震动。
+ * <p>
+ * 在录音机进程内 hook NotificationManager.notify，对目标通知补上：
+ * <ul>
+ *     <li>android.progressMax / android.progress / android.progressIndeterminate
+ *         extras — 让接收方 inflate 标准模板时看到 ProgressBar，能被进度过滤器
+ *         识别。</li>
+ *     <li>FLAG_ONGOING_EVENT — 让 StatusBarNotification.isOngoing() 返回 true，
+ *         触发监听方的 ongoing 通知过滤。</li>
+ * </ul>
+ * 完成通知 (&quot;AI转写完成&quot;) 标题里没有百分比，不命中正则，照常下发。
+ */
+public class MarkTranscribeProgress extends BaseHook {
+
+    private static final int TARGET_ID = 1001;
+    private static final String TARGET_CHANNEL = "channel_id_record_recognition";
+    private static final Pattern PROGRESS_PATTERN = Pattern.compile("(\\d{1,3})\\s*%");
+
+    @Override
+    public void init() {
+        findAndHookMethod(NotificationManager.class, "notify",
+            int.class, Notification.class,
+            new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    fixProgress((Integer) param.getArgs()[0], (Notification) param.getArgs()[1]);
+                }
+            });
+
+        findAndHookMethod(NotificationManager.class, "notify",
+            String.class, int.class, Notification.class,
+            new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    fixProgress((Integer) param.getArgs()[1], (Notification) param.getArgs()[2]);
+                }
+            });
+    }
+
+    private static void fixProgress(int id, Notification n) {
+        if (n == null || id != TARGET_ID) return;
+        if (!TARGET_CHANNEL.equals(n.getChannelId())) return;
+
+        Bundle extras = n.extras;
+        if (extras == null) return;
+
+        CharSequence title = extras.getCharSequence(Notification.EXTRA_TITLE);
+        if (title == null) return;
+
+        Matcher m = PROGRESS_PATTERN.matcher(title);
+        if (!m.find()) return;
+
+        int percent;
+        try {
+            percent = Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            return;
+        }
+        if (percent < 0 || percent > 100) return;
+
+        extras.putInt(Notification.EXTRA_PROGRESS_MAX, 100);
+        extras.putInt(Notification.EXTRA_PROGRESS, percent);
+        extras.putBoolean(Notification.EXTRA_PROGRESS_INDETERMINATE, false);
+
+        n.flags |= Notification.FLAG_ONGOING_EVENT;
+    }
+}


### PR DESCRIPTION
## 现象

录音机的 AI 转写过程中，凡是接 `NotificationListenerService` 的下游应用 (小米运动健康/手环同步、第三方手表 App 等) 会把每 1% 变化都当成一条全新通知重新推送。表现是佩戴手环时，转写过程中手环每隔几秒就震一次，直到转写结束。

## 原因

录音机这条通知 (`channel=channel_id_record_recognition`, `id=1001`) 把进度写在标题里 (`AI转写中 NN%`)，但**既没调用 `Notification.Builder.setProgress()`，也没调用 `setOngoing()`**。

设备实测的通知形态：

```text
Notification(channel=channel_id_record_recognition ... flags=ONLY_ALERT_ONCE|NO_CLEAR|FOREGROUND_SERVICE)
extras={
  android.title=String (AI转写中 12%)
  android.text=String (周二 16点12分)
}
contentView=null
bigContentView=null
```

下游应用判定"这是进度通知 / ongoing 通知所以不要重复同步"的常见手段有两条：

1. inflate 通知布局，在 view tree 里找可见的 `ProgressBar`  
2. 看 `StatusBarNotification.isOngoing()`

录音机这条两条都不命中：标题写百分比 → view tree 里没有 `ProgressBar`；缺 `setOngoing(true)` → `isOngoing()` 返回 false。所以下游每次都按"新通知"处理。

(以小米运动健康 `BaseNotifySyncService.handleNotificationPosted` 为例：两道过滤都不命中 → `MSG_NOTIFY_ADD` → 推送到手环。它内部确实有跨包的进度去重 `mProgressNotificationTemp`，但需要 `isProgressNotification()` 先返回 true 才会启用。)

## 修复

在录音机进程内 hook `NotificationManager.notify` 的两个 overload，对目标通知出栈前补全：

- `extras` 加 `android.progressMax=100` / `android.progress=<percent>` / `android.progressIndeterminate=false`  
  → 系统默认模板 inflate 出来就带 `ProgressBar`，下游基于 view tree 的进度过滤器能识别。
- `flags |= FLAG_ONGOING_EVENT`  
  → `StatusBarNotification.isOngoing()` 返回 true，覆盖另一道常见过滤。

判定条件 (三者全部命中才改):

```java
id == 1001
channelId == "channel_id_record_recognition"
title 匹配 (\d{1,3})\s*%
```

完成通知 (`AI转写完成`) 标题没百分比，正则不命中，**照常下发**，手环还能收到完成提示。

## UI

新增开关 (默认关)：**录音机 → 录音转写改为标准进度通知**  
*"补上标准进度条与持续状态标识，解决转写过程被小米运动健康等通知监听 App 每 1% 重复推送到手环/手表的问题。"*

## 验证

- 设备：Xiaomi `pudding`，OS3.0.309.0.WPCCNXM (HyperOS 3 / Android 16)
- 录音机：`com.android.soundrecorder` 7.8.9.3-bc34f3e22
- 小米运动健康：`com.mi.health` 3.55.0 + 连接的手环
- 实测：开启开关、重启录音机后启动 AI 转写 → 手环不再每 1% 震一次，完成时仍正常收到 `AI转写完成`。

## 范围

仅 hook 录音机自己进程内的 `NotificationManager.notify`，且严格按 `id + channelId + title 正则` 匹配，不影响录音机其他通知，更不影响其他 App。