### PR TITLE
fix:修复pad引导式访问无法阻止推出手势的问题

### DIFF
--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/home/recent/GuidedAccessHome.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/home/recent/GuidedAccessHome.java
@@ -30,6 +30,7 @@ import com.sevtinge.hyperceiler.common.utils.PrefsBridge;
 import com.sevtinge.hyperceiler.libhook.base.BaseHook;
 
 import io.github.libxposed.api.XposedInterface;
+import io.github.lingqiqi5211.ezhooktool.xposed.EzXposed;
 
 public class GuidedAccessHome extends BaseHook {
     private static final String SETTING_KEY_LOCK_APP = "key_lock_app";
@@ -40,8 +41,42 @@ public class GuidedAccessHome extends BaseHook {
         hookIsMistakeTouch();
         hookScreenPinTouchResolution();
         hookLandscapeOverviewGestureView();
+        hookGestureModeHelper();
         hookScreenPinnedHelperStartDirectly();
         hookHomeStartScreenPinningDirectly();
+    }
+
+    /**
+     * Pad 上"底部中间上滑退出固定应用"由桌面进程的 GestureModeScreenPinning 接管，
+     * 它识别手势后会抢占触摸并弹出退出 UI（NavStubView 的 hook 覆盖不到这条链路）。
+     * 锁定期间强制退回 GestureModeEmpty，让该手势完全失效；解锁后自动恢复正常。
+     */
+    private void hookGestureModeHelper() {
+        // pad 专有的手势模式选择类；手机桌面没有该类或字段时直接跳过，避免反射异常。
+        Class<?> helperClass = findClassIfExists("com.miui.home.recents.GestureModeHelper");
+        if (helperClass == null) return;
+        try {
+            helperClass.getDeclaredField("mGestureModeEmpty");
+        } catch (NoSuchFieldException e) {
+            return;
+        }
+
+        chainAllMethods(helperClass, "createGestureMode", new XposedInterface.Hooker() {
+            @Override
+            public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                if (!isLocked()) return chain.proceed();
+                Object result = chain.proceed();
+                try {
+                    Object emptyMode = getObjectField(chain.getThisObject(), "mGestureModeEmpty");
+                    if (emptyMode == null || emptyMode == result) return result;
+                    XposedLog.d(TAG, "GuidedAccess: forced empty gesture mode while locked");
+                    return emptyMode;
+                } catch (Throwable t) {
+                    XposedLog.w(TAG, "GuidedAccess: force empty gesture mode E: " + t);
+                    return result;
+                }
+            }
+        });
     }
 
     private void hookPointerEvent() {
@@ -172,6 +207,10 @@ public class GuidedAccessHome extends BaseHook {
         } catch (Throwable ignored) {
         }
         return null;
+    }
+
+    private boolean isLocked() {
+        return getLockApp(EzXposed.getAppContextOrNull()) != -1;
     }
 
     private int getLockApp(Context context) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/SystemLockApp.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/SystemLockApp.java
@@ -37,7 +37,7 @@ import io.github.libxposed.api.XposedInterface;
  * @author 焕晨HChen
  */
 public class SystemLockApp extends BaseHook {
-    private static final long POWER_HOLD_EXIT_MS = 3000L;
+    private static final long POWER_HOLD_EXIT_MS = 1000L;
     private static final long SUPPRESS_POWER_MENU_AFTER_EXIT_MS = 1500L;
     private static final long TRANSIENT_BLOCK_LOG_INTERVAL_MS = 1200L;
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/SystemLockApp.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/SystemLockApp.java
@@ -21,8 +21,10 @@ package com.sevtinge.hyperceiler.libhook.rules.systemframework.others;
 import static com.sevtinge.hyperceiler.libhook.base.BaseHook.setBooleanField;
 
 import android.content.Context;
+import android.database.ContentObserver;
 import android.os.Binder;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.SystemClock;
 import android.provider.Settings;
 import android.view.WindowInsets;
@@ -51,7 +53,6 @@ public class SystemLockApp extends BaseHook {
     private static final String PHONE_WINDOW_MANAGER_CLASS = "com.android.server.policy.PhoneWindowManager";
     private static final String MIUI_SHORTCUT_ACTIONS_CLASS = "com.miui.server.input.util.ShortCutActionsUtils";
     private static final String INSETS_POLICY_CLASS = "com.android.server.wm.InsetsPolicy";
-    private static final String DISPLAY_POLICY_CLASS = "com.android.server.wm.DisplayPolicy";
 
     private static final String ACTION_LONG_PRESS_POWER_KEY = "long_press_power_key";
     private static final String ACTION_IMPERCEPTIBLE_PRESS_POWER_KEY = "imperceptible_press_power_key";
@@ -60,6 +61,7 @@ public class SystemLockApp extends BaseHook {
     boolean isLock = false;
     private volatile long mLastPowerExitUptimeMs = 0L;
     private volatile long mLastTransientBlockLogUptimeMs = 0L;
+    private boolean mObserverRegistered = false;
 
     @Override
     public void init() {
@@ -83,6 +85,7 @@ public class SystemLockApp extends BaseHook {
                         mLastPowerExitUptimeMs = 0L;
                         setLockApp(context, lockTaskId);
                         applyGestureLineShielding(context, true);
+                        registerObserverIfNeeded(context);
                     } catch (Throwable e) {
                         XposedLog.e(TAG, "startSystemLockTaskMode E: " + e);
                     } finally {
@@ -98,10 +101,20 @@ public class SystemLockApp extends BaseHook {
             new XposedInterface.Hooker() {
                 @Override
                 public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                    Context context = (Context) getObjectField(chain.getThisObject(), "mContext");
+                    int callingPid = Binder.getCallingPid();
+
+                    // 核心拦截逻辑：只有在锁定状态，且调用者不是系统进程自身，且没有电源键退出标志时才拦截
+                    if (isLock && context != null && getLockApp(context) != -1) {
+                        if (callingPid != android.os.Process.myPid() && !shouldSuppressPowerActionNow()) {
+                            XposedLog.d(TAG, "GuidedAccess: Blocked unauthorized stopSystemLockTaskMode from PID: " + callingPid);
+                            return null;
+                        }
+                    }
+
                     Object result = chain.proceed();
                     long identity = Binder.clearCallingIdentity();
                     try {
-                        Context context = (Context) getObjectField(chain.getThisObject(), "mContext");
                         if (context == null) return result;
 
                         isLock = false;
@@ -161,6 +174,24 @@ public class SystemLockApp extends BaseHook {
         );
     }
 
+    private void registerObserverIfNeeded(Context context) {
+        if (mObserverRegistered || context == null) return;
+        context.getContentResolver().registerContentObserver(
+            Settings.Global.getUriFor(SETTING_KEY_LOCK_APP),
+            false,
+            new ContentObserver(new Handler(context.getMainLooper())) {
+                @Override
+                public void onChange(boolean selfChange) {
+                    if (getLockApp(context) == -1 && isLock) {
+                        XposedLog.d(TAG, "External unlock detected, calling stopSystemLockTaskMode");
+                        stopSystemLockTaskMode();
+                    }
+                }
+            }
+        );
+        mObserverRegistered = true;
+    }
+
     private void hookMiuiPowerLongPressTimeout() {
         Class<?> ruleClass = findClassIfExists(MIUI_POWER_KEY_RULE_CLASS);
         if (ruleClass != null) {
@@ -175,8 +206,6 @@ public class SystemLockApp extends BaseHook {
             } catch (Throwable e) {
                 XposedLog.w(TAG, "Hook getMiuiLongPressTimeoutMs failed: " + e);
             }
-        } else {
-            XposedLog.w(TAG, "Miui power key rule class not found: " + MIUI_POWER_KEY_RULE_CLASS);
         }
     }
 
@@ -202,7 +231,6 @@ public class SystemLockApp extends BaseHook {
                     }
                     if (!isLock) return chain.proceed(args);
 
-                    // 固定应用中统一改为 3 秒触发，并把 0.5 秒链路归并到 long_press_power_key 处理。
                     args[1] = (int) POWER_HOLD_EXIT_MS;
                     if (ACTION_IMPERCEPTIBLE_PRESS_POWER_KEY.equals(shortcut)) {
                         args[2] = ACTION_LONG_PRESS_POWER_KEY;
@@ -216,104 +244,66 @@ public class SystemLockApp extends BaseHook {
     }
 
     private void hookMiuiPowerShortcutTrigger() {
-        try {
-            findAndChainMethod(MIUI_SHORTCUT_ACTIONS_CLASS,
-                "triggerFunction",
-                new XposedInterface.Hooker() {
-                    @Override
-                    public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                        String action = (String) chain.getArg(1);
-                        if (!isLock && !shouldSuppressPowerActionNow()) return chain.proceed();
-                        return interceptPowerShortcutAction(action, isLock, chain);
-                    }
-                },
-                String.class, String.class, Bundle.class, boolean.class, String.class
-            );
-        } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook triggerFunction(5) failed: " + e);
-        }
+        XposedInterface.Hooker triggerHooker = new XposedInterface.Hooker() {
+            @Override
+            public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                String action = (String) chain.getArg(1);
+                if (!isLock && !shouldSuppressPowerActionNow()) return chain.proceed();
+                return interceptPowerShortcutAction(action, isLock, chain);
+            }
+        };
 
         try {
-            findAndChainMethod(MIUI_SHORTCUT_ACTIONS_CLASS,
-                "triggerFunction",
-                new XposedInterface.Hooker() {
-                    @Override
-                    public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                        String action = (String) chain.getArg(1);
-                        if (!isLock && !shouldSuppressPowerActionNow()) return chain.proceed();
-                        return interceptPowerShortcutAction(action, isLock, chain);
-                    }
-                },
-                String.class, String.class, Bundle.class, boolean.class
-            );
-        } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook triggerFunction(4) failed: " + e);
-        }
+            findAndChainMethod(MIUI_SHORTCUT_ACTIONS_CLASS, "triggerFunction", triggerHooker,
+                String.class, String.class, Bundle.class, boolean.class, String.class);
+        } catch (Throwable ignored) {}
+
+        try {
+            findAndChainMethod(MIUI_SHORTCUT_ACTIONS_CLASS, "triggerFunction", triggerHooker,
+                String.class, String.class, Bundle.class, boolean.class);
+        } catch (Throwable ignored) {}
     }
 
     private Object interceptPowerShortcutAction(String action, boolean lockedNow, XposedInterface.Chain chain) throws Throwable {
-        if (ACTION_IMPERCEPTIBLE_PRESS_POWER_KEY.equals(action)) {
-            // 0.5s 语音/无感按压链路：仅吞掉，不退出固定应用。
-            return true;
-        }
+        if (ACTION_IMPERCEPTIBLE_PRESS_POWER_KEY.equals(action)) return true;
         if (!ACTION_LONG_PRESS_POWER_KEY.equals(action)) return chain.proceed();
-        if (!lockedNow && shouldSuppressPowerActionNow()) {
+
+        if (lockedNow) {
+            XposedLog.d(TAG, "Power long press detected, exiting GuidedAccess");
+            markPowerExitAndSuppressMenuWindow();
+            stopSystemLockTaskMode();
             return true;
         }
 
-        // 3s 长按触发：沿用官方退出流程（stopSystemLockTaskMode）。
-        markPowerExitAndSuppressMenuWindow();
-        stopSystemLockTaskMode();
-        return true;
+        if (shouldSuppressPowerActionNow()) return true;
+        return chain.proceed();
     }
 
     private void hookSuppressPowerMenuAfterExit() {
         Class<?> pwmClass = findClassIfExists(PHONE_WINDOW_MANAGER_CLASS);
         if (pwmClass == null) return;
 
-        try {
-            chainAllMethods(pwmClass, "powerLongPress", new XposedInterface.Hooker() {
-                @Override
-                public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                    if (isLock) {
-                        markPowerExitAndSuppressMenuWindow();
-                        stopSystemLockTaskMode();
-                        trySetPowerKeyHandled(chain.getThisObject(), true);
-                        return null;
-                    }
-                    if (!shouldSuppressPowerActionNow()) return chain.proceed();
+        XposedInterface.Hooker suppressHooker = new XposedInterface.Hooker() {
+            @Override
+            public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                if (isLock) {
+                    markPowerExitAndSuppressMenuWindow();
+                    stopSystemLockTaskMode();
                     trySetPowerKeyHandled(chain.getThisObject(), true);
                     return null;
                 }
-            });
-        } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook powerLongPress failed: " + e);
-        }
+                if (!shouldSuppressPowerActionNow()) return chain.proceed();
+                trySetPowerKeyHandled(chain.getThisObject(), true);
+                return null;
+            }
+        };
 
         try {
-            chainAllMethods(pwmClass, "showGlobalActions", new XposedInterface.Hooker() {
-                @Override
-                public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                    if (!shouldSuppressPowerActionNow()) return chain.proceed();
-                    trySetPowerKeyHandled(chain.getThisObject(), true);
-                    return null;
-                }
-            });
+            chainAllMethods(pwmClass, "powerLongPress", suppressHooker);
+            chainAllMethods(pwmClass, "showGlobalActions", suppressHooker);
+            chainAllMethods(pwmClass, "showGlobalActionsInternal", suppressHooker);
         } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook showGlobalActions failed: " + e);
-        }
-
-        try {
-            chainAllMethods(pwmClass, "showGlobalActionsInternal", new XposedInterface.Hooker() {
-                @Override
-                public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                    if (!shouldSuppressPowerActionNow()) return chain.proceed();
-                    trySetPowerKeyHandled(chain.getThisObject(), true);
-                    return null;
-                }
-            });
-        } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook showGlobalActionsInternal failed: " + e);
+            XposedLog.w(TAG, "Hook PWM power actions failed: " + e);
         }
     }
 
@@ -323,31 +313,13 @@ public class SystemLockApp extends BaseHook {
                 @Override
                 public Object intercept(XposedInterface.Chain chain) throws Throwable {
                     if (!isLock || !isEnhancedShieldEnabled()) return chain.proceed();
-                    int types = 0;
-                    if (!chain.getArgs().isEmpty() && chain.getArg(0) instanceof Integer) {
-                        types = (Integer) chain.getArg(0);
-                    }
+                    int types = (Integer) chain.getArg(0);
                     if ((types & WindowInsets.Type.navigationBars()) == 0) return chain.proceed();
                     debugTransientBlock("block InsetsPolicy.showTransient types=" + types);
                     return null;
                 }
             });
-        } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook InsetsPolicy.showTransient failed: " + e);
-        }
-
-        try {
-            chainAllMethods(DISPLAY_POLICY_CLASS, "requestTransientBars", new XposedInterface.Hooker() {
-                @Override
-                public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                    if (!isLock || !isEnhancedShieldEnabled()) return chain.proceed();
-                    debugTransientBlock("block DisplayPolicy.requestTransientBars");
-                    return null;
-                }
-            });
-        } catch (Throwable e) {
-            XposedLog.w(TAG, "Hook DisplayPolicy.requestTransientBars failed: " + e);
-        }
+        } catch (Throwable ignored) {}
     }
 
     private void trySetPowerKeyHandled(Object pwmObj, boolean handled) {
@@ -387,16 +359,11 @@ public class SystemLockApp extends BaseHook {
             restoreGestureLineState(context);
             return;
         }
-
-        if (!PrefsBridge.getBoolean("system_framework_guided_access_status")) return;
+        if (!isEnhancedShieldEnabled()) return;
 
         try {
             if (mGestureLineBeforeLock == null) {
-                mGestureLineBeforeLock = Settings.Global.getInt(
-                    context.getContentResolver(),
-                    SETTING_HIDE_GESTURE_LINE,
-                    HIDE_GESTURE_LINE_SHOW
-                );
+                mGestureLineBeforeLock = Settings.Global.getInt(context.getContentResolver(), SETTING_HIDE_GESTURE_LINE, HIDE_GESTURE_LINE_SHOW);
             }
             Settings.Global.putInt(context.getContentResolver(), SETTING_HIDE_GESTURE_LINE, HIDE_GESTURE_LINE_HIDE);
         } catch (Throwable e) {
@@ -405,9 +372,7 @@ public class SystemLockApp extends BaseHook {
     }
 
     private void restoreGestureLineState(Context context) {
-        if (context == null) return;
-        if (mGestureLineBeforeLock == null) return;
-
+        if (context == null || mGestureLineBeforeLock == null) return;
         try {
             Settings.Global.putInt(context.getContentResolver(), SETTING_HIDE_GESTURE_LINE, mGestureLineBeforeLock);
         } catch (Throwable e) {
@@ -424,10 +389,9 @@ public class SystemLockApp extends BaseHook {
     public int getLockApp(Context context) {
         try {
             return Settings.Global.getInt(context.getContentResolver(), SETTING_KEY_LOCK_APP);
-        } catch (Settings.SettingNotFoundException e) {
-            XposedLog.e(TAG, getPackageName(), "getInt hyceiler_lock_app E: " + e);
+        } catch (Throwable ignored) {
+            return -1;
         }
-        return -1;
     }
 
     private boolean isEnhancedShieldEnabled() {
@@ -437,14 +401,11 @@ public class SystemLockApp extends BaseHook {
     private void stopSystemLockTaskMode() {
         try {
             Class<?> activityTaskManager = findClassIfExists("android.app.ActivityTaskManager");
-            if (activityTaskManager == null) {
-                XposedLog.w(TAG, "ActivityTaskManager class is null");
-                return;
-            }
+            if (activityTaskManager == null) return;
             Object service = callStaticMethod(activityTaskManager, "getService");
             callMethod(service, "stopSystemLockTaskMode");
         } catch (Throwable e) {
-            XposedLog.e(TAG, "Power hold exit lock task E: " + e);
+            XposedLog.e(TAG, "stopSystemLockTaskMode helper E: " + e);
         }
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/other/UiLockApp.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/other/UiLockApp.java
@@ -119,7 +119,7 @@ public class UiLockApp extends BaseHook {
             hookTaskbarDelegateClass(className);
         }
         if (isPad()) {
-            hookLauncherProxyStopScreenPinning();
+            hookISystemUiProxyStopScreenPinning();
         }
     }
 
@@ -267,20 +267,23 @@ public class UiLockApp extends BaseHook {
         }
     }
 
-    private void hookLauncherProxyStopScreenPinning() {
-        Class<?> launcherProxyClass = findClassIfExists("com.android.systemui.recents.LauncherProxyService$1");
-        if (launcherProxyClass == null) return;
+    private void hookISystemUiProxyStopScreenPinning() {
+        // 动态定位 ISystemUiProxy 接口的实现类，这比硬编码 LauncherProxyService$1 更健壮
+        Class<?> proxyClass = findClassIfExists("com.android.systemui.recents.OverviewProxyService$1");
+        if (proxyClass == null) {
+            proxyClass = findClassIfExists("com.android.systemui.recents.LauncherProxyService$1");
+        }
 
-        chainAllMethods(launcherProxyClass, "verifyCallerAndClearCallingIdentityPostMain", new XposedInterface.Hooker() {
+        if (proxyClass == null) return;
+
+        chainAllMethods(proxyClass, "stopScreenPinning", new XposedInterface.Hooker() {
             @Override
             public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                Object[] args = chain.getArgs().toArray();
-                if (args.length > 0 && "stopScreenPinning".equals(args[0])) {
-                    Context context = resolveContext(chain.getThisObject());
-                    if (context != null && getLockApp(context) != -1) {
-                        XposedLog.d(TAG, "block LauncherProxyService.stopScreenPinning while locked");
-                        return null;
-                    }
+                Context context = resolveContext(chain.getThisObject());
+                int lockApp = getLockApp(context);
+                if (context != null && lockApp != -1) {
+                    XposedLog.d(TAG, "GuidedAccess: Blocked ISystemUiProxy.stopScreenPinning in SystemUI");
+                    return null; // 拦截桌面发来的解锁指令
                 }
                 return chain.proceed();
             }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/other/UiLockApp.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/other/UiLockApp.java
@@ -20,6 +20,7 @@ package com.sevtinge.hyperceiler.libhook.rules.systemui.other;
 
 import static com.sevtinge.hyperceiler.libhook.utils.api.DeviceHelper.Miui.isPad;
 
+import android.app.ActivityManager;
 import android.content.Context;
 import android.database.ContentObserver;
 import android.os.Handler;
@@ -45,6 +46,7 @@ import io.github.libxposed.api.XposedInterface;
  */
 public class UiLockApp extends BaseHook {
     private static final String SETTING_KEY_LOCK_APP = "key_lock_app";
+    private static final String SETTING_HIDE_GESTURE_LINE = "hide_gesture_line";
     private static final String STATE_CONTEXT = "UiLockApp.context";
     private static final String STATE_STATUS_BAR_VIEW = "UiLockApp.statusBarView";
 
@@ -94,6 +96,12 @@ public class UiLockApp extends BaseHook {
             new XposedInterface.Hooker() {
                 @Override
                 public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                    try {
+                        Context context = (Context) callMethod(chain.getThisObject(), "getApplicationContext");
+                        reconcileStaleLockState(context);
+                    } catch (Throwable e) {
+                        XposedLog.w(TAG, "reconcile stale lock state E: " + e);
+                    }
                     Object result = chain.proceed();
                     try {
                         Context context = (Context) callMethod(chain.getThisObject(), "getApplicationContext");
@@ -120,6 +128,26 @@ public class UiLockApp extends BaseHook {
         }
         if (isPad()) {
             hookISystemUiProxyStopScreenPinning();
+        }
+    }
+
+    /**
+     * 意外重启后 ATMS 的 lock task 状态必然清零，但 key_lock_app 是持久化设置会残留，
+     * 导致 SystemUI 把系统误判为锁定中（状态栏/手势条被隐藏、手势被禁用），无法退出。
+     * 这里以框架真实状态为准：真实锁定中（如 SystemUI 单独重启）不动，残留则清掉镜像设置。
+     */
+    private void reconcileStaleLockState(Context context) {
+        if (context == null || getLockApp(context) == -1) return;
+        try {
+            Object activityManager = context.getSystemService(Context.ACTIVITY_SERVICE);
+            if (activityManager == null) return;
+            int lockTaskState = (Integer) callMethod(activityManager, "getLockTaskModeState");
+            if (lockTaskState == ActivityManager.LOCK_TASK_MODE_LOCKED) return;
+            XposedLog.d(TAG, "clear stale lock state after reboot, lockTaskState=" + lockTaskState);
+            Settings.Global.putInt(context.getContentResolver(), SETTING_KEY_LOCK_APP, -1);
+            Settings.Global.putInt(context.getContentResolver(), SETTING_HIDE_GESTURE_LINE, 0);
+        } catch (Throwable e) {
+            XposedLog.w(TAG, "reconcileStaleLockState E: " + e);
         }
     }
 


### PR DESCRIPTION
虽然进行了较大改动，但修改后逻辑仍然清晰且兼容性更好还修复了问题
同时将电源键推出时间缩短到1秒，优化体验（1秒与触发关机与重启界面的时间相似，且与强制重启的时间区分区分够大，避免长按后没反应造成的困惑）