### PR TITLE
fix(oobe): stabilize onboarding transitions

### DIFF
--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/HomePageActivity.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/HomePageActivity.java
@@ -10,10 +10,17 @@ import static com.sevtinge.hyperceiler.libhook.utils.api.DeviceHelper.System.get
 import static com.sevtinge.hyperceiler.libhook.utils.api.DeviceHelper.System.getVersionListText;
 import static com.sevtinge.hyperceiler.libhook.utils.api.DeviceHelper.System.isVersionListed;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.AnimatorSet;
+import android.animation.ObjectAnimator;
+import android.animation.TimeInterpolator;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.CountDownTimer;
+import android.view.View;
+import android.view.ViewTreeObserver;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -38,6 +45,7 @@ import com.sevtinge.hyperceiler.home.widget.NavigationStyle;
 import com.sevtinge.hyperceiler.home.widget.SwitchManager;
 import com.sevtinge.hyperceiler.home.widget.SwitchMediator;
 import com.sevtinge.hyperceiler.provision.utils.NoticeProvider;
+import com.sevtinge.hyperceiler.provision.utils.OobeTransitionHelper;
 import com.sevtinge.hyperceiler.provision.utils.ProvisionManager;
 import com.sevtinge.hyperceiler.settings.SettingsFragment;
 import com.sevtinge.hyperceiler.settings.SettingsPageFragment;
@@ -60,12 +68,38 @@ public class HomePageActivity extends AppCompatActivity
     PreferenceFragment.OnPreferenceStartFragmentCallback {
 
     private static final String STATE_CURRENT_PAGE = "home_current_page";
-
+    private static final float OOBE_HOME_START_SCALE = 1.4f;
+    private static final long OOBE_HOME_ALPHA_DELAY_MS = 60L;
+    private static final long OOBE_HOME_ALPHA_DURATION_MS = 230L;
+    private static final long OOBE_HOME_SCALE_DURATION_MS = 619L;
+    private static final TimeInterpolator OOBE_HOME_ALPHA_INTERPOLATOR = fraction ->
+        (float) Math.sin(fraction * Math.PI / 2d);
+    private static final TimeInterpolator OOBE_HOME_SPRING_INTERPOLATOR = fraction -> {
+        if (fraction <= 0f) return 0f;
+        if (fraction >= 1f) return 1f;
+        double dampingRatio = 0.65d;
+        double angularFrequency = 10.5d;
+        double dampingRoot = Math.sqrt(1d - dampingRatio * dampingRatio);
+        double dampedFrequency = angularFrequency * dampingRoot;
+        double envelope = Math.exp(-dampingRatio * angularFrequency * fraction);
+        return (float) (1d - envelope * (
+            Math.cos(dampedFrequency * fraction) +
+                dampingRatio / dampingRoot * Math.sin(dampedFrequency * fraction)
+        ));
+    };
     public ViewPager mViewPager;
     public HomeContentAdapter mContentAdapter;
 
     public SwitchManager mSwitchManager;
     private boolean mIsUnsupportedVersionExiting;
+    private View mHomeRoot;
+    private AnimatorSet mHomeRevealAnimator;
+    private ViewTreeObserver.OnPreDrawListener mHomeRevealPreDrawListener;
+    private ViewTreeObserver.OnPreDrawListener mHomeReadyPreDrawListener;
+    private int mHomeRootLayerType = View.LAYER_TYPE_NONE;
+    private boolean mCheckVersionAfterReveal;
+    private boolean mLaunchOobeWhenReady;
+    private final Runnable mScheduleHomeRevealRunnable = this::scheduleHomeReveal;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -76,18 +110,25 @@ public class HomePageActivity extends AppCompatActivity
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (PersistConfig.isAprilFoolsThemeView) setTheme(R.style.HomePageAprilFoolsTheme);
-        if (!OobeUtils.isProvisioned(this) && !OobeUtils.isDebugOobeMode(this)) {
+        boolean prepareHomeForOobe = getIntent().getBooleanExtra(
+            OobeTransitionHelper.EXTRA_PREPARE_HOME,
+            false
+        );
+        if (!OobeUtils.isProvisioned(this) && !OobeUtils.isDebugOobeMode(this) &&
+            !prepareHomeForOobe) {
             startActivity(new Intent(this, SplashActivity.class));
             finish();
             return;
         }
-        if (!isVersionListed()) {
+        if (!prepareHomeForOobe && !isVersionListed()) {
             showUnsupportedVersionDialog();
             return;
         }
+        OobeTransitionHelper.resetHomeReady();
         // Activity 启动阶段，绑定 UI 任务（如签名校验弹窗、公告展示）
         AppInitializer.initOnActivityCreate(this, this);
         setContentView(R.layout.activity_home);
+        mHomeRoot = findViewById(R.id.container);
         setupNavigation();
         restoreCurrentPage(savedInstanceState);
 
@@ -100,6 +141,153 @@ public class HomePageActivity extends AppCompatActivity
             }
             return list;
         });
+        mLaunchOobeWhenReady = prepareHomeForOobe && savedInstanceState == null;
+        scheduleHomeReady();
+    }
+
+    private void launchOobe() {
+        Intent intent = new Intent(
+            this,
+            com.sevtinge.hyperceiler.provision.activity.DefaultActivity.class
+        );
+        startActivity(intent);
+        overridePendingTransition(0, 0);
+    }
+
+    private void scheduleHomeReady() {
+        if (mHomeRoot == null || mHomeReadyPreDrawListener != null) return;
+        mHomeReadyPreDrawListener = () -> {
+            removeHomeReadyPreDrawListener();
+            if (mLaunchOobeWhenReady) {
+                mLaunchOobeWhenReady = false;
+                OobeTransitionHelper.markHomeReady();
+                launchOobe();
+                return false;
+            }
+            mHomeRoot.postOnAnimation(() ->
+                mHomeRoot.postOnAnimation(OobeTransitionHelper::markHomeReady)
+            );
+            return true;
+        };
+        mHomeRoot.getViewTreeObserver().addOnPreDrawListener(mHomeReadyPreDrawListener);
+        mHomeRoot.invalidate();
+    }
+
+    private void prepareHomeReveal() {
+        if (mHomeRoot == null) return;
+        mHomeRoot.setScaleX(OOBE_HOME_START_SCALE);
+        mHomeRoot.setScaleY(OOBE_HOME_START_SCALE);
+        mHomeRoot.setAlpha(0f);
+    }
+
+    private void scheduleHomeReveal() {
+        if (mHomeRoot == null || mHomeRevealPreDrawListener != null) return;
+        mHomeRevealPreDrawListener = () -> {
+            removeHomeRevealPreDrawListener();
+            startHomeReveal();
+            return true;
+        };
+        mHomeRoot.getViewTreeObserver().addOnPreDrawListener(mHomeRevealPreDrawListener);
+        mHomeRoot.invalidate();
+    }
+
+    private void startHomeReveal() {
+        if (mHomeRoot == null || isFinishing() || isDestroyed()) return;
+        if (mHomeRoot.getWidth() <= 0 || mHomeRoot.getHeight() <= 0) {
+            scheduleHomeReveal();
+            return;
+        }
+
+        mHomeRoot.setPivotX(mHomeRoot.getWidth() / 2f);
+        mHomeRoot.setPivotY(mHomeRoot.getHeight() / 2f);
+        mHomeRootLayerType = mHomeRoot.getLayerType();
+        mHomeRoot.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+
+        ObjectAnimator scaleX = ObjectAnimator.ofFloat(
+            mHomeRoot,
+            View.SCALE_X,
+            OOBE_HOME_START_SCALE,
+            1f
+        );
+        scaleX.setDuration(OOBE_HOME_SCALE_DURATION_MS);
+        scaleX.setInterpolator(OOBE_HOME_SPRING_INTERPOLATOR);
+
+        ObjectAnimator scaleY = ObjectAnimator.ofFloat(
+            mHomeRoot,
+            View.SCALE_Y,
+            OOBE_HOME_START_SCALE,
+            1f
+        );
+        scaleY.setDuration(OOBE_HOME_SCALE_DURATION_MS);
+        scaleY.setInterpolator(OOBE_HOME_SPRING_INTERPOLATOR);
+
+        ObjectAnimator alpha = ObjectAnimator.ofFloat(
+            mHomeRoot,
+            View.ALPHA,
+            0f,
+            1f
+        );
+        alpha.setStartDelay(OOBE_HOME_ALPHA_DELAY_MS);
+        alpha.setDuration(OOBE_HOME_ALPHA_DURATION_MS);
+        alpha.setInterpolator(OOBE_HOME_ALPHA_INTERPOLATOR);
+
+        AnimatorSet animator = new AnimatorSet();
+        animator.playTogether(scaleX, scaleY, alpha);
+        animator.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if (mHomeRevealAnimator != animator) return;
+                mHomeRevealAnimator = null;
+                restoreHomeTransform();
+                if (mCheckVersionAfterReveal) {
+                    mCheckVersionAfterReveal = false;
+                    if (!isVersionListed()) showUnsupportedVersionDialog();
+                }
+            }
+        });
+        mHomeRevealAnimator = animator;
+        animator.start();
+    }
+
+    private void removeHomeRevealPreDrawListener() {
+        if (mHomeRoot == null || mHomeRevealPreDrawListener == null) return;
+        ViewTreeObserver observer = mHomeRoot.getViewTreeObserver();
+        if (observer.isAlive()) {
+            observer.removeOnPreDrawListener(mHomeRevealPreDrawListener);
+        }
+        mHomeRevealPreDrawListener = null;
+    }
+
+    private void removeHomeReadyPreDrawListener() {
+        if (mHomeRoot == null || mHomeReadyPreDrawListener == null) return;
+        ViewTreeObserver observer = mHomeRoot.getViewTreeObserver();
+        if (observer.isAlive()) {
+            observer.removeOnPreDrawListener(mHomeReadyPreDrawListener);
+        }
+        mHomeReadyPreDrawListener = null;
+    }
+
+    private void cancelHomeReveal() {
+        AnimatorSet animator = mHomeRevealAnimator;
+        mHomeRevealAnimator = null;
+        if (animator != null) {
+            animator.removeAllListeners();
+            animator.cancel();
+        }
+        if (mHomeRoot != null) {
+            mHomeRoot.removeCallbacks(mScheduleHomeRevealRunnable);
+        }
+        removeHomeRevealPreDrawListener();
+        removeHomeReadyPreDrawListener();
+        restoreHomeTransform();
+    }
+
+    private void restoreHomeTransform() {
+        if (mHomeRoot == null) return;
+        mHomeRoot.setScaleX(1f);
+        mHomeRoot.setScaleY(1f);
+        mHomeRoot.setAlpha(1f);
+        mHomeRoot.setLayerType(mHomeRootLayerType, null);
     }
 
     private void setupNavigation() {
@@ -160,6 +348,16 @@ public class HomePageActivity extends AppCompatActivity
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        setIntent(intent);
+        if (intent.getBooleanExtra(OobeTransitionHelper.EXTRA_HOME_REVEAL, false)) {
+            intent.removeExtra(OobeTransitionHelper.EXTRA_HOME_REVEAL);
+            mCheckVersionAfterReveal = true;
+            prepareHomeReveal();
+            if (mHomeRoot != null) {
+                mHomeRoot.removeCallbacks(mScheduleHomeRevealRunnable);
+                mHomeRoot.postOnAnimation(mScheduleHomeRevealRunnable);
+            }
+        }
     }
 
     public SwitchManager getSwitchManager() {
@@ -205,6 +403,7 @@ public class HomePageActivity extends AppCompatActivity
 
     @Override
     public void onDestroy() {
+        cancelHomeReveal();
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/sevtinge/hyperceiler/ui/SplashActivity.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/ui/SplashActivity.java
@@ -25,7 +25,7 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 
 import com.sevtinge.hyperceiler.home.safemode.AppCrashStore;
-import com.sevtinge.hyperceiler.provision.activity.DefaultActivity;
+import com.sevtinge.hyperceiler.provision.utils.OobeTransitionHelper;
 
 import fan.appcompat.app.AppCompatActivity;
 import fan.provision.OobeUtils;
@@ -52,8 +52,9 @@ public class SplashActivity extends AppCompatActivity {
             // 跳转到主页
             intent = new Intent(this, HomePageActivity.class);
         } else {
-            // 跳转到引导页
-            intent = new Intent(this, DefaultActivity.class);
+            // 主页先在 OOBE 下层完成布局，结束引导时直接复用。
+            intent = new Intent(this, HomePageActivity.class);
+            intent.putExtra(OobeTransitionHelper.EXTRA_PREPARE_HOME, true);
         }
         startActivity(intent);
         // 3. 必须 finish，否则用户按返回键会回到空白的 Splash 页面

--- a/library/provision/src/main/AndroidManifest.xml
+++ b/library/provision/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <application>
         <activity
             android:name=".activity.DefaultActivity"
+            android:enableOnBackInvokedCallback="false"
             android:exported="true"
             android:theme="@style/ProvisionTheme">
             <intent-filter>
@@ -17,21 +18,25 @@
 
         <activity
             android:name=".activity.PermissionSettingsActivity"
+            android:enableOnBackInvokedCallback="false"
             android:exported="true"
             android:theme="@style/ProvisionTheme" />
 
         <activity
             android:name=".activity.TermsAndStatementActivity"
+            android:enableOnBackInvokedCallback="false"
             android:exported="true"
             android:theme="@style/ProvisionTheme" />
 
         <activity
             android:name=".activity.BasicSettingsActivity"
+            android:enableOnBackInvokedCallback="false"
             android:exported="true"
             android:theme="@style/ProvisionTheme" />
 
         <activity
             android:name=".activity.CongratulationActivity"
+            android:enableOnBackInvokedCallback="false"
             android:exported="true"
             android:theme="@style/ProvisionTheme" />
 

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/BaseActivity.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/BaseActivity.java
@@ -18,7 +18,9 @@
  */
 package com.sevtinge.hyperceiler.provision.activity;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -33,7 +35,9 @@ import androidx.fragment.app.FragmentTransaction;
 
 import com.sevtinge.hyperceiler.common.utils.AppLanguageHelper;
 import com.sevtinge.hyperceiler.provision.R;
+import com.sevtinge.hyperceiler.provision.utils.OobeTransitionHelper;
 import com.sevtinge.hyperceiler.provision.utils.PageIntercepHelper;
+import com.sevtinge.hyperceiler.provision.utils.ProvisionStateHolder;
 
 import fan.provision.OobeUtils;
 import fan.provision.ProvisionBaseActivity;
@@ -51,26 +55,27 @@ public abstract class BaseActivity extends ProvisionBaseActivity {
 
     private boolean mCheckNewJump = true;
     private boolean mIsDisableBack = false;
+    private boolean mNavigationCommitted;
+    private boolean mWaitingForNextPage;
 
     private final View.OnClickListener mBackListener = v -> getOnBackPressedDispatcher().onBackPressed();
 
     private final OnBackPressedCallback mBackCallback = new OnBackPressedCallback(true) {
         @Override
         public void handleOnBackPressed() {
-            if (!mIsDisableBack) {
-                try {
-                    additionalProcess();
-                    if (!getSupportFragmentManager().isDestroyed()) {
-                        setEnabled(false);
-                        getOnBackPressedDispatcher().onBackPressed();
-                        setEnabled(true);
-                    }
-                    if (mFragment != null) {
-                        mFragment.getClass();
-                    }
-                } catch (Exception e) {
-                    Log.e("BaseActivity", "ex: " + e.getMessage());
+            if (mIsDisableBack || mNavigationCommitted) return;
+            try {
+                additionalProcess();
+                if (!(BaseActivity.this instanceof PermissionSettingsActivity)) {
+                    ProvisionStateHolder.getInstance().moveToPreviousActivity();
                 }
+                mNavigationCommitted = true;
+                updateButtonState(false);
+                finishAfterTransition();
+            } catch (Exception e) {
+                mNavigationCommitted = false;
+                updateButtonState(true);
+                Log.e("BaseActivity", "ex: " + e.getMessage());
             }
         }
     };
@@ -86,6 +91,13 @@ public abstract class BaseActivity extends ProvisionBaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (!(this instanceof PermissionSettingsActivity)) {
+            overrideActivityTransition(
+                Activity.OVERRIDE_TRANSITION_CLOSE,
+                R.anim.provision_slide_in_left,
+                R.anim.provision_slide_out_right
+            );
+        }
         getOnBackPressedDispatcher().addCallback(this, mBackCallback);
         if (OobeUtils.isProvisioned(this) && !OobeUtils.isDebugOobeMode(this)) {
             setResult(-1);
@@ -128,6 +140,11 @@ public abstract class BaseActivity extends ProvisionBaseActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        if (mWaitingForNextPage) {
+            mWaitingForNextPage = false;
+            mNavigationCommitted = false;
+            updateButtonState(true);
+        }
         if (mTitle != null) {
             mTitle.setTextDirection(OobeUtils.isRTL() ? 4 : 3);
             int titleStringId = getTitleStringId();
@@ -166,6 +183,28 @@ public abstract class BaseActivity extends ProvisionBaseActivity {
 
     protected void additionalProcess() {
         setResult(0);
+    }
+
+    public final void navigateForward() {
+        if (mNavigationCommitted) return;
+        Intent intent = ProvisionStateHolder.getInstance().moveToNextActivity();
+        if (intent == null) {
+            Log.e("BaseActivity", "next OOBE state is unavailable");
+            return;
+        }
+
+        mNavigationCommitted = true;
+        mWaitingForNextPage = true;
+        updateButtonState(false);
+        try {
+            startActivity(intent, OobeTransitionHelper.createPageOptions(this, true));
+        } catch (RuntimeException exception) {
+            ProvisionStateHolder.getInstance().moveToPreviousActivity();
+            mWaitingForNextPage = false;
+            mNavigationCommitted = false;
+            updateButtonState(true);
+            Log.e("BaseActivity", "failed to open next OOBE page", exception);
+        }
     }
 
     protected void setPreviewDrawable(int id) {

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/BaseActivity.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/BaseActivity.java
@@ -44,19 +44,19 @@ import fan.provision.ProvisionBaseActivity;
 
 public abstract class BaseActivity extends ProvisionBaseActivity {
 
-    @Override
-    protected void attachBaseContext(Context newBase) {
-        // 引导页面中的所有子页面 Activity 都应跨语言切换后同步语言，
-        // 否则仅 DefaultActivity 被包裹会造成子页面仍然显示旧语言。
-        super.attachBaseContext(AppLanguageHelper.wrapContext(newBase));
-    }
-
     protected Fragment mFragment;
 
     private boolean mCheckNewJump = true;
     private boolean mIsDisableBack = false;
     private boolean mNavigationCommitted;
     private boolean mWaitingForNextPage;
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        // 引导页面中的所有子页面 Activity 都应跨语言切换后同步语言，
+        // 否则仅 DefaultActivity 被包裹会造成子页面仍然显示旧语言。
+        super.attachBaseContext(AppLanguageHelper.wrapContext(newBase));
+    }
 
     private final View.OnClickListener mBackListener = v -> getOnBackPressedDispatcher().onBackPressed();
 

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/BasicSettingsActivity.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/BasicSettingsActivity.java
@@ -58,7 +58,6 @@ public class BasicSettingsActivity extends BaseActivity {
     @Override
     public void onNextAminStart() {
         super.onNextAminStart();
-        setResult(-1);
-        finish();
+        navigateForward();
     }
 }

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/DefaultActivity.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/DefaultActivity.java
@@ -27,6 +27,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -53,6 +54,18 @@ public class DefaultActivity extends ProvisionBaseActivity {
 
     private StateMachine mStateMachine;
 
+    private final OnBackPressedCallback mBackCallback = new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+            if (OobeUtils.isDebugOobeMode(DefaultActivity.this)) {
+                setEnabled(false);
+                finishAfterTransition();
+            } else {
+                moveTaskToBack(true);
+            }
+        }
+    };
+
     private final Handler mHandler = new Handler(Looper.getMainLooper());
     private int mPendingRequestCode = -1;
     private final ActivityResultLauncher<Intent> mActivityResultLauncher = registerForActivityResult(
@@ -72,6 +85,7 @@ public class DefaultActivity extends ProvisionBaseActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getOnBackPressedDispatcher().addCallback(this, mBackCallback);
         if (isDeviceIsProvisioned() && !OobeUtils.isDebugOobeMode(this)) {
             finishSetup();
             return;

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/PermissionSettingsActivity.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/PermissionSettingsActivity.java
@@ -62,8 +62,7 @@ public class PermissionSettingsActivity extends BaseActivity {
     @Override
     public void onNextAminStart() {
         super.onNextAminStart();
-        setResult(-1);
-        finish();
+        navigateForward();
     }
 
     public void enableBtnClick() {

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/TermsAndStatementActivity.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/activity/TermsAndStatementActivity.java
@@ -62,10 +62,4 @@ public class TermsAndStatementActivity extends BaseActivity {
         }
     }
 
-    @Override
-    public void onBackAnimStart() {
-        super.onBackAnimStart();
-        setResult(0);
-        finish();
-    }
 }

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/fragment/CongratulationFragment.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/fragment/CongratulationFragment.java
@@ -36,6 +36,7 @@ import com.sevtinge.hyperceiler.provision.R;
 import com.sevtinge.hyperceiler.provision.renderengine.GlowController;
 import com.sevtinge.hyperceiler.provision.renderengine.RenderViewLayout;
 import com.sevtinge.hyperceiler.provision.utils.IOnFocusListener;
+import com.sevtinge.hyperceiler.provision.utils.OobeTransitionHelper;
 import com.sevtinge.hyperceiler.provision.utils.Utils;
 
 import fan.animation.Folme;
@@ -62,6 +63,8 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
 
     private boolean isFirstBoot = true;
     private boolean isComplete;
+    private boolean mHomeLaunchStarted;
+    private boolean mCompletionButtonAnimationReady;
 
     private View mGlowEffectView;
     private View mContentView;
@@ -76,6 +79,8 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
     private GlowController mGlowController;
 
     private final Handler mHandler = new Handler();
+    private final OobeTransitionHelper.HomeReadyListener mHomeReadyListener = ready ->
+        updateCompletionButtonEnabled();
 
     @Override
     protected int getLayoutId() {
@@ -90,6 +95,7 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
         initView(view);
         initBackGround();
         setupBlurBackground();
+        OobeTransitionHelper.registerHomeReadyListener(mHomeReadyListener);
         displayOSLogoDelay();
     }
 
@@ -113,8 +119,8 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
         mNextView.setEnabled(false);
         Folme.use(mNextView).touch().setScale(1.0f).handleTouchOf(this.mNextView);
         mNextView.setOnClickListener(v -> {
+            if (mHomeLaunchStarted || !OobeTransitionHelper.isHomeReady()) return;
             startHome();
-            startPageAnim();
         });
     }
 
@@ -247,7 +253,8 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
         if (view == null) return;
 
         view.postDelayed(() -> {
-            view.setEnabled(true);
+            mCompletionButtonAnimationReady = true;
+            updateCompletionButtonEnabled();
             Log.d("ProvisionCongratulationActivity", "startBtnAnim: mNextView setEnabled");
         }, 2000L);
         if (view.getVisibility() == View.VISIBLE) return;
@@ -257,34 +264,14 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
             @Override
             public void onComplete(Object toTag) {
                 super.onComplete(toTag);
-                view.setEnabled(true);
+                mCompletionButtonAnimationReady = true;
+                updateCompletionButtonEnabled();
                 Log.d("ProvisionCongratulationActivity", "onComplete: mNextView setEnabled");
             }
         });
         IStateStyle state = Folme.use(view).state();
         ViewProperty viewProperty = ViewProperty.ALPHA;
         state.setTo(viewProperty, Float.valueOf(0.0f)).to(viewProperty, Float.valueOf(1.0f), delay);
-    }
-
-    private void startPageAnim() {
-        AnimState animState = new AnimState("start");
-        ViewProperty viewProperty = ViewProperty.ALPHA;
-        AnimState add = animState.add(viewProperty, 1.0d);
-        ViewProperty viewProperty2 = ViewProperty.SCALE_X;
-        AnimState add2 = add.add(viewProperty2, 1.0d);
-        ViewProperty viewProperty3 = ViewProperty.SCALE_Y;
-        AnimState add3 = add2.add(viewProperty3, 1.0d);
-        AnimState add4 = new AnimState("end").add(viewProperty, 0.0d).add(viewProperty2, 0.8d).add(viewProperty3, 0.8d);
-        AnimConfig animConfig = new AnimConfig();
-        animConfig.setSpecial(viewProperty2, FolmeEase.spring(1.0f, 0.36f));
-        animConfig.setSpecial(viewProperty3, FolmeEase.spring(1.0f, 0.36f));
-        animConfig.setSpecial(viewProperty, FolmeEase.sinOut(360L));
-        if (mLogoImageWrapper != null) {
-            Folme.use(mLogoImageWrapper).state().setTo(add3).to(add4, animConfig);
-        }
-        if (mNextView != null) {
-            Folme.use(mNextView).state().setTo(add3).to(add4, animConfig);
-        }
     }
 
     @Override
@@ -334,33 +321,62 @@ public class CongratulationFragment extends BaseFragment implements IOnFocusList
     }
 
     private void startHome() {
+        if (mHomeLaunchStarted || !OobeTransitionHelper.isHomeReady()) return;
+        mHomeLaunchStarted = true;
+        if (mNextView != null) mNextView.setEnabled(false);
+
         boolean isDebugOobe = OobeUtils.isDebugOobeMode(requireActivity());
+        boolean wasProvisioned = OobeUtils.isProvisioned(requireContext());
         if (!isDebugOobe) {
             AppLanguageHelper.freezeCurrentLocaleIfUnset(requireContext());
             OobeUtils.setProvisioned(requireContext(), true);
         }
         try {
-            ActivityOptions customTaskAnimation = ActivityOptions.makeCustomAnimation(requireContext(), R.anim.enter_home_anim, R.anim.provision_out_anim);
+            ActivityOptions customTaskAnimation = ActivityOptions.makeCustomAnimation(
+                requireContext(),
+                R.anim.enter_home_anim,
+                R.anim.provision_out_anim
+            );
             startActivity(getHomeIntent(), customTaskAnimation.toBundle());
+            requireActivity().overridePendingTransition(
+                R.anim.enter_home_anim,
+                R.anim.provision_out_anim,
+                requireContext().getColor(R.color.provision_home_transition_background)
+            );
             Log.d(TAG, "startHome success " + customTaskAnimation);
-        } catch (Exception ex) {}
-        Log.e(TAG, "getActivityOptions fail");
-        finish();
+            finish();
+        } catch (RuntimeException exception) {
+            Log.e(TAG, "startHome failed", exception);
+            if (!isDebugOobe) {
+                OobeUtils.setProvisioned(requireContext(), wasProvisioned);
+            }
+            mHomeLaunchStarted = false;
+            updateCompletionButtonEnabled();
+        }
+    }
+
+    private void updateCompletionButtonEnabled() {
+        if (mNextView == null) return;
+        mNextView.setEnabled(
+            mCompletionButtonAnimationReady &&
+                OobeTransitionHelper.isHomeReady() &&
+                !mHomeLaunchStarted
+        );
     }
 
 
     private Intent getHomeIntent() {
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.setPackage(requireContext().getPackageName());
-        if (OobeUtils.isDebugOobeMode(requireActivity())) {
-            intent.setClassName(requireContext(), "com.sevtinge.hyperceiler.ui.HomePageActivity");
-            intent.putExtra(OobeUtils.EXTRA_DEBUG_OOBE, true);
-        } else {
-            intent.setClassName(requireContext(), "com.sevtinge.hyperceiler.ui.SplashActivity");
-        }
-        // 清除掉引导页所在的整个任务栈
-        // 这样跳转后，栈内只有主页，按返回键会直接回到手机桌面
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        intent.setClassName(requireContext(), "com.sevtinge.hyperceiler.ui.HomePageActivity");
+        intent.putExtra(OobeTransitionHelper.EXTRA_HOME_REVEAL, true);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         return intent;
+    }
+
+    @Override
+    public void onDestroyView() {
+        OobeTransitionHelper.unregisterHomeReadyListener(mHomeReadyListener);
+        super.onDestroyView();
     }
 }

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/fragment/StartupFragment.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/fragment/StartupFragment.java
@@ -57,8 +57,12 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
         }
 
     private final boolean IS_SUPPORT_WELCOME_ANIM = !OobeUtils.isLiteOrLowDevice();
+    private static final long PERMISSION_LAUNCH_TIMEOUT_MS = 1200L;
 
     private long lastClickTime = 0;
+    private boolean mLaunchPending;
+    private boolean mPermissionLaunchStarted;
+    private PickPageAnimationContext mPendingAnimationContext;
 
     private ImageView mBackgroundImage;
     private View mMiuiEnterLayout;
@@ -96,8 +100,18 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
         restoreNextButtonState();
         Utils.IS_START_ANIMA = false;
     };
+    private final Runnable mPermissionLaunchFallbackRunnable = () -> {
+        PickPageAnimationContext context = mPendingAnimationContext;
+        if (!mLaunchPending || mPermissionLaunchStarted || context == null) return;
+        AndroidLog.w(TAG, "permission page capture timed out, using fallback animation");
+        launchPermissionPickPage(context, null);
+    };
 
     private final View.OnClickListener mNextClickListener = v -> {
+        if (mLaunchPending) {
+            AndroidLog.d(TAG, "permission page launch is already pending");
+            return;
+        }
         long jCurrentTimeMillis = System.currentTimeMillis();
         if (Math.abs(jCurrentTimeMillis - lastClickTime) < 2000) {
             AndroidLog.d(TAG, "click too fast");
@@ -111,9 +125,17 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
             AndroidLog.w(TAG, "click next button: activity or next view is unavailable");
             return;
         }
+        mLaunchPending = true;
+        setNextButtonInteractionEnabled(false);
         Utils.isFirstBoot = false;
         PickPageAnimationContext pickPageAnimationContext = buildPickPageAnimationContext(defaultActivity, nextView);
+        mPendingAnimationContext = pickPageAnimationContext;
         defaultActivity.run(-1);
+        mMainHandler.removeCallbacks(mPermissionLaunchFallbackRunnable);
+        mMainHandler.postDelayed(
+            mPermissionLaunchFallbackRunnable,
+            PERMISSION_LAUNCH_TIMEOUT_MS
+        );
         enterLanguagePickPage(pickPageAnimationContext);
     };
 
@@ -227,8 +249,19 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
     @Override
     public void onResume() {
         super.onResume();
+        if (mLaunchPending) return;
         lastClickTime = 0;
         syncNextButtonState();
+    }
+
+    public void onReturnToStartup() {
+        mMainHandler.removeCallbacks(mPermissionLaunchFallbackRunnable);
+        mLaunchPending = false;
+        mPermissionLaunchStarted = false;
+        mPendingAnimationContext = null;
+        lastClickTime = 0;
+        Utils.IS_START_ANIMA = false;
+        restoreNextButtonState();
     }
 
     @Override
@@ -290,6 +323,7 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
         AndroidLog.i(TAG, "onDestroy");
         mMainHandler.removeCallbacks(mDisplayOsAndoRunnable);
         mMainHandler.removeCallbacks(mRestoreNextButtonRunnable);
+        mMainHandler.removeCallbacks(mPermissionLaunchFallbackRunnable);
         if (mAnimationHandler != null) {
             mAnimationHandler.removeCallbacksAndMessages(null);
         }
@@ -316,32 +350,30 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
     private void hideNextButtonState() {
         if (mNextLayout != null) {
             mNextLayout.setVisibility(View.INVISIBLE);
-            mNextLayout.setEnabled(false);
-            mNextLayout.setClickable(false);
         }
-        if (mNext != null) {
-            mNext.setEnabled(false);
-            mNext.setClickable(false);
-        }
-        if (mNextArrow != null) {
-            mNextArrow.setEnabled(false);
-            mNextArrow.setClickable(false);
-        }
+        setNextButtonInteractionEnabled(false);
     }
 
     private void restoreNextButtonState() {
+        if (mLaunchPending) return;
         if (mNextLayout != null) {
             mNextLayout.setVisibility(View.VISIBLE);
-            mNextLayout.setEnabled(true);
-            mNextLayout.setClickable(true);
+        }
+        setNextButtonInteractionEnabled(true);
+    }
+
+    private void setNextButtonInteractionEnabled(boolean enabled) {
+        if (mNextLayout != null) {
+            mNextLayout.setEnabled(enabled);
+            mNextLayout.setClickable(enabled);
         }
         if (mNext != null) {
-            mNext.setEnabled(true);
-            mNext.setClickable(true);
+            mNext.setEnabled(enabled);
+            mNext.setClickable(enabled);
         }
         if (mNextArrow != null) {
-            mNextArrow.setEnabled(true);
-            mNextArrow.setClickable(true);
+            mNextArrow.setEnabled(enabled);
+            mNextArrow.setClickable(enabled);
         }
     }
 
@@ -375,13 +407,20 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
 
 
     private void launchPermissionPickPage(@NonNull PickPageAnimationContext animationContext, @Nullable Bitmap bitmap) {
+        if (!mLaunchPending || mPermissionLaunchStarted) {
+            recycleBitmap(bitmap);
+            return;
+        }
         DefaultActivity activity = animationContext.activity;
         if (activity.isFinishing() || activity.isDestroyed()) {
             AndroidLog.w(TAG, "launchPermissionPickPage: activity unavailable after bitmap capture");
+            recycleBitmap(bitmap);
             return;
         }
 
-        ActivityOptions activityOptions = bitmap != null ? buildPickPageAnimation(animationContext, bitmap) : null;
+        ActivityOptions activityOptions = bitmap != null
+            ? buildPickPageAnimation(animationContext, bitmap)
+            : buildFallbackPageAnimation(animationContext);
 
         if (activityOptions == null) {
             if (bitmap == null) {
@@ -389,13 +428,52 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
             } else {
                 AndroidLog.w(TAG, "launchPermissionPickPage: scale-up animation is unavailable, launching without ActivityOptions");
             }
+            recycleBitmap(bitmap);
             Utils.IS_START_ANIMA = false;
-            activity.enterCurrentState(null);
-            return;
+        } else if (bitmap == null) {
+            Utils.IS_START_ANIMA = false;
         }
 
-        AndroidLog.d(TAG, "launchPermissionPickPage: start activity with scale-up animation");
-        activity.enterCurrentState(activityOptions.toBundle());
+        mPermissionLaunchStarted = true;
+        mMainHandler.removeCallbacks(mPermissionLaunchFallbackRunnable);
+        try {
+            AndroidLog.d(TAG, "launchPermissionPickPage: start permission activity");
+            activity.enterCurrentState(
+                activityOptions == null ? null : activityOptions.toBundle()
+            );
+            if (mNextLayout != null) {
+                mNextLayout.setVisibility(View.INVISIBLE);
+            }
+        } catch (RuntimeException exception) {
+            AndroidLog.e(TAG, "launchPermissionPickPage failed: " + exception);
+            mPermissionLaunchStarted = false;
+            activity.run(0);
+            onReturnToStartup();
+        }
+    }
+
+    @Nullable
+    private ActivityOptions buildFallbackPageAnimation(
+        @NonNull PickPageAnimationContext animationContext
+    ) {
+        try {
+            return ActivityOptions.makeScaleUpAnimation(
+                animationContext.nextView,
+                0,
+                0,
+                animationContext.nextView.getWidth(),
+                animationContext.nextView.getHeight()
+            );
+        } catch (RuntimeException exception) {
+            AndroidLog.w(TAG, "fallback scale-up animation is unavailable: " + exception);
+            return null;
+        }
+    }
+
+    private void recycleBitmap(@Nullable Bitmap bitmap) {
+        if (bitmap != null && bitmap != Utils.CACHE_BITMAP && !bitmap.isRecycled()) {
+            bitmap.recycle();
+        }
     }
 
     @Nullable
@@ -445,7 +523,7 @@ public class StartupFragment extends BaseFragment implements IOnFocusListener {
     private Runnable buildExitFinishCallback(@Nullable View nextLayout) {
         return () -> {
             if (nextLayout != null) {
-                nextLayout.setVisibility(View.VISIBLE);
+                nextLayout.setVisibility(mLaunchPending ? View.INVISIBLE : View.VISIBLE);
                 AndroidLog.d(TAG, "exitFinishCallback: " + nextLayout.getVisibility());
             }
         };

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/fragment/TermsAndStatementFragment.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/fragment/TermsAndStatementFragment.java
@@ -41,6 +41,7 @@ import androidx.annotation.Nullable;
 import com.sevtinge.hyperceiler.common.log.AndroidLog;
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge;
 import com.sevtinge.hyperceiler.provision.R;
+import com.sevtinge.hyperceiler.provision.activity.BaseActivity;
 import com.sevtinge.hyperceiler.provision.text.style.TermsTitleSpan;
 import com.sevtinge.hyperceiler.provision.utils.NoticeProvider;
 import com.sevtinge.hyperceiler.provision.utils.ProvisionManager;
@@ -237,9 +238,8 @@ public class TermsAndStatementFragment extends BaseFragment {
     }
 
     public void goNext() {
-        if (getActivity() != null) {
-            getActivity().setResult(-1);
-            getActivity().finish();
+        if (getActivity() instanceof BaseActivity activity) {
+            activity.navigateForward();
         }
     }
 

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/state/StartupState.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/state/StartupState.java
@@ -33,6 +33,10 @@ public class StartupState extends State implements IKeyEvent, IOnFocusListener {
         Fragment fragment = fragmentManager.findFragmentByTag(StartupFragment.class.getSimpleName());
         if (fragment instanceof StartupFragment startupFragment) {
             mStartupFragment = startupFragment;
+            if (mHasBooted) {
+                mHasBooted = false;
+                mStartupFragment.onReturnToStartup();
+            }
             return;
         }
         mStartupFragment = new StartupFragment();

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/state/StateMachine.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/state/StateMachine.java
@@ -10,13 +10,13 @@ import android.util.SparseArray;
 import androidx.annotation.Nullable;
 
 import com.sevtinge.hyperceiler.common.log.AndroidLog;
-import com.sevtinge.hyperceiler.provision.R;
 import com.sevtinge.hyperceiler.provision.activity.BasicSettingsActivity;
 import com.sevtinge.hyperceiler.provision.activity.CongratulationActivity;
 import com.sevtinge.hyperceiler.provision.activity.DefaultActivity;
 import com.sevtinge.hyperceiler.provision.activity.PermissionSettingsActivity;
 import com.sevtinge.hyperceiler.provision.activity.TermsAndStatementActivity;
 import com.sevtinge.hyperceiler.provision.utils.PageIntercepHelper;
+import com.sevtinge.hyperceiler.provision.utils.OobeTransitionHelper;
 
 import java.util.ArrayList;
 
@@ -209,10 +209,40 @@ public class StateMachine {
             AndroidLog.d(TAG, "transitToNext: PermissionState");
             //OobeUtils.checkAndActivateEsimAfterFactoryReset(mContext);
         } else {
-            mCurrentState.onEnter(mCurrentState.canBackTo(), true);
-            ((DefaultActivity) mContext).overridePendingTransition(R.anim.provision_slide_in_right, R.anim.provision_slide_out_left);
+            mCurrentState.onEnter(
+                mCurrentState.canBackTo(),
+                true,
+                OobeTransitionHelper.createPageOptions(mContext, true)
+            );
         }
         saveState();
+    }
+
+    @Nullable
+    public Intent moveToNextActivity() {
+        State nextState = getNextAvailableState(mCurrentState);
+        if (nextState == null) return null;
+
+        mCurrentState.onLeave();
+        mStateStack.add(mCurrentState);
+        mCurrentState = nextState;
+        int size = mStateStack.size() - 1;
+        Intent intent = mCurrentState.createEnterIntent(
+            size >= 0 && mStateStack.get(size).canBackTo(),
+            true
+        );
+        saveState();
+        return intent;
+    }
+
+    public boolean moveToPreviousActivity() {
+        if (mStateStack.isEmpty()) return false;
+
+        State leavingState = mCurrentState;
+        mCurrentState = getPreviousAvailableState(mStateStack);
+        leavingState.onLeave();
+        saveState();
+        return true;
     }
 
     private boolean needFinish() {
@@ -221,16 +251,20 @@ public class StateMachine {
 
     private void transitToPrevious() {
         if (mStateStack.size() <= 0) return;
+        State leavingState = mCurrentState;
         mCurrentState = getPreviousAvailableState(mStateStack);
+        leavingState.onLeave();
         if (mCurrentState instanceof StartupState) {
             ((StartupState) mCurrentState).setBooted(true);
+            int size = mStateStack.size() - 1;
+            mCurrentState.onEnter(size >= 0 && mStateStack.get(size).canBackTo(), false);
         } else {
-            mCurrentState.onLeave();
-        }
-        int size = mStateStack.size() - 1;
-        mCurrentState.onEnter(size >= 0 && mStateStack.get(size).canBackTo(), false);
-        if (!(mCurrentState instanceof PermissionState)) {
-            ((DefaultActivity) this.mContext).overridePendingTransition(R.anim.provision_slide_in_left, R.anim.provision_slide_out_right);
+            int size = mStateStack.size() - 1;
+            mCurrentState.onEnter(
+                size >= 0 && mStateStack.get(size).canBackTo(),
+                false,
+                OobeTransitionHelper.createPageOptions(mContext, false)
+            );
         }
         saveState();
     }

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/utils/OobeTransitionHelper.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/utils/OobeTransitionHelper.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of HyperCeiler.
+ *
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2023-2026 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.provision.utils;
+
+import android.app.ActivityOptions;
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+
+import com.sevtinge.hyperceiler.provision.R;
+
+import java.lang.ref.WeakReference;
+
+public final class OobeTransitionHelper {
+
+    public static final String EXTRA_HOME_REVEAL =
+        "com.sevtinge.hyperceiler.extra.OOBE_HOME_REVEAL";
+    public static final String EXTRA_PREPARE_HOME =
+        "com.sevtinge.hyperceiler.extra.PREPARE_HOME_FOR_OOBE";
+    private static boolean sHomeReady;
+    private static WeakReference<HomeReadyListener> sHomeReadyListener =
+        new WeakReference<>(null);
+
+    private OobeTransitionHelper() {}
+
+    public interface HomeReadyListener {
+        void onHomeReadyChanged(boolean ready);
+    }
+
+    public static void resetHomeReady() {
+        sHomeReady = false;
+        notifyHomeReadyChanged();
+    }
+
+    public static void markHomeReady() {
+        sHomeReady = true;
+        notifyHomeReadyChanged();
+    }
+
+    public static boolean isHomeReady() {
+        return sHomeReady;
+    }
+
+    public static void registerHomeReadyListener(@NonNull HomeReadyListener listener) {
+        sHomeReadyListener = new WeakReference<>(listener);
+        listener.onHomeReadyChanged(sHomeReady);
+    }
+
+    public static void unregisterHomeReadyListener(@NonNull HomeReadyListener listener) {
+        if (sHomeReadyListener.get() == listener) {
+            sHomeReadyListener.clear();
+        }
+    }
+
+    private static void notifyHomeReadyChanged() {
+        HomeReadyListener listener = sHomeReadyListener.get();
+        if (listener != null) listener.onHomeReadyChanged(sHomeReady);
+    }
+
+    @NonNull
+    public static Bundle createPageOptions(@NonNull Context context, boolean forward) {
+        int enterAnimation = forward
+            ? R.anim.provision_slide_in_right
+            : R.anim.provision_slide_in_left;
+        int exitAnimation = forward
+            ? R.anim.provision_slide_out_left
+            : R.anim.provision_slide_out_right;
+        return ActivityOptions.makeCustomAnimation(
+            context,
+            enterAnimation,
+            exitAnimation
+        ).toBundle();
+    }
+}

--- a/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/utils/ProvisionStateHolder.java
+++ b/library/provision/src/main/java/com/sevtinge/hyperceiler/provision/utils/ProvisionStateHolder.java
@@ -18,6 +18,10 @@
  */
 package com.sevtinge.hyperceiler.provision.utils;
 
+import android.content.Intent;
+
+import androidx.annotation.Nullable;
+
 import com.sevtinge.hyperceiler.provision.state.StateMachine;
 
 public class ProvisionStateHolder {
@@ -38,6 +42,15 @@ public class ProvisionStateHolder {
 
     public void setStateMachine(StateMachine stateMachine) {
         mStateMachine = stateMachine;
+    }
+
+    @Nullable
+    public Intent moveToNextActivity() {
+        return mStateMachine == null ? null : mStateMachine.moveToNextActivity();
+    }
+
+    public boolean moveToPreviousActivity() {
+        return mStateMachine != null && mStateMachine.moveToPreviousActivity();
     }
 
 }

--- a/library/provision/src/main/res/anim/enter_home_anim.xml
+++ b/library/provision/src/main/res/anim/enter_home_anim.xml
@@ -1,19 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:shareInterpolator="false">
-    <scale
-        android:duration="619"
-        android:fromXScale="1.3"
-        android:fromYScale="1.3"
-        android:interpolator="@anim/enter_home_spring_interpolator"
-        android:pivotX="50%"
-        android:pivotY="50%"
-        android:toXScale="1.0"
-        android:toYScale="1.0" />
     <alpha
-        android:duration="230"
-        android:fromAlpha="0.0"
-        android:interpolator="@anim/sine_in_out_interpolator"
-        android:startOffset="60"
+        android:duration="619"
+        android:fromAlpha="1.0"
         android:toAlpha="1.0" />
 </set>

--- a/library/provision/src/main/res/values/colors.xml
+++ b/library/provision/src/main/res/values/colors.xml
@@ -46,4 +46,5 @@
 
     <color name="anim_foreground_color">#99000000</color>
     <color name="anim_foreground_color_blur_enable">#00ffffff</color>
+    <color name="provision_home_transition_background">@color/miuix_default_color_surface_low_light</color>
 </resources>


### PR DESCRIPTION
## 修改内容

- 统一 OOBE 详情页前进/返回的 Activity 转场与导航提交状态，拦截快速连点，避免状态机与实际页面不同步。
- 完善欢迎页进入权限页的异步截图交接，增加超时降级、重复回调保护及 Bitmap 回收。
- 修复权限页快速继续、连续返回时短暂跳回欢迎页以及箭头状态丢失的问题。
- 首次启动时在 OOBE 下层预加载 Home；完成页等待 Home 就绪后再允许进入，并复用已加载主页播放淡入/下沉动画，避免白屏。
- 完成页启动主页失败时恢复完成状态并重新启用按钮，避免停留在不可恢复状态。
- 普通首次 OOBE 在欢迎页返回时将任务移至后台；Debug OOBE 返回时正常关闭并回到 Home。
- OOBE Activity 关闭预测性返回回调，保持自定义返回动画一致。

## 根因

OOBE 状态机推进、欢迎页异步截图和 Activity 启动原先分别执行。快速操作时，状态已经前进但目标页面尚未启动，后续 result/back 又会再次修改状态，导致跳屏和返回动画丢失。完成阶段原先清理任务栈并重新创建主页，也会产生白屏和不连续的进入动画。

## 状态与任务栈

- 未新增或修改 SharedPreferences key。
- 正常 OOBE 仍只在完成页写入 `is_provisioned` 与 Hook 门控；Debug OOBE 不写真实完成状态。
- 首次启动的 Home 作为 OOBE 下层页面提前布局；完成后使用 `CLEAR_TOP | SINGLE_TOP` 复用该实例。
- 主页启动失败时回滚完成标志，不修改 Log 服务。

## 验证

- [x] `./gradlew :app:assembleDebug`
- [x] `git diff --check`
- [ ] 清数据后的完整真机 OOBE 回归矩阵未在本次提交阶段重新执行
- [ ] 平板横屏、RTL、旋转和进程回收场景未验证