### PR TITLE
云服务: 国际版 ROM 下为中国区账号解除相册云同步封锁

### DIFF
--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/CloudService.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/CloudService.java
@@ -22,11 +22,13 @@ import com.hchen.database.HookBase;
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge;
 import com.sevtinge.hyperceiler.libhook.base.BaseLoad;
 import com.sevtinge.hyperceiler.libhook.rules.cloudservice.CloudList;
+import com.sevtinge.hyperceiler.libhook.rules.cloudservice.RestoreGallerySync;
 
 @HookBase(targetPackage = "com.miui.cloudservice")
 public class CloudService extends BaseLoad {
     @Override
     public void onPackageLoaded() {
         initHook(new CloudList(), PrefsBridge.getBoolean("micloud_service_list"));
+        initHook(new RestoreGallerySync(), PrefsBridge.getStringAsInt("gallery_backup_server", 0) == 1);
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/cloudservice/RestoreGallerySync.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/cloudservice/RestoreGallerySync.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2026 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.libhook.rules.cloudservice;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+import com.sevtinge.hyperceiler.common.log.XposedLog;
+import com.sevtinge.hyperceiler.libhook.base.BaseHook;
+import com.sevtinge.hyperceiler.libhook.utils.api.ContextUtils;
+
+import io.github.lingqiqi5211.ezhooktool.xposed.common.HookParam;
+import io.github.lingqiqi5211.ezhooktool.xposed.java.IMethodHook;
+
+/**
+ * 國際版 ROM 上，CloudService 會無條件執行相簿雲同步終止邏輯
+ * （ServiceTerminatedHelper：setIsSyncable(gallery, 0) + setSyncAutomatically(gallery, false)），
+ * 導致伺服器仍支援相簿同步的帳號（如中國區）也無法同步（介面卡在「正在請求」）。
+ *
+ * 當使用者在相簿選擇小米雲作為備份伺服器（gallery_backup_server == 1）、
+ * 且小米帳號註冊區域為 CN 時自動生效：
+ * 攔截上述兩個寫入，並在 CloudService 啟動時主動修復同步狀態。
+ */
+public class RestoreGallerySync extends BaseHook {
+    private static final String TAG = "RestoreGallerySync";
+    private static final String AUTHORITY = "com.miui.gallery.cloud.provider";
+    private static final String ACCOUNT_TYPE = "com.xiaomi";
+
+    // 1: 尚未檢查, 2: CN 帳號, 3: 非 CN 帳號
+    private static volatile int sIsCnAccount = 1;
+
+    @Override
+    public void init() {
+        findAndHookMethod(ContentResolver.class, "setIsSyncable",
+            Account.class, String.class, int.class, new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    Object[] args = param.getArgs();
+                    if (args != null && args.length == 3
+                        && AUTHORITY.equals(args[1]) && ((int) args[2]) <= 0 && isCnAccount()) {
+                        param.setResult(null);
+                    }
+                }
+            });
+        findAndHookMethod(ContentResolver.class, "setSyncAutomatically",
+            Account.class, String.class, boolean.class, new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    Object[] args = param.getArgs();
+                    if (args != null && args.length == 3
+                        && AUTHORITY.equals(args[1]) && !((boolean) args[2]) && isCnAccount()) {
+                        param.setResult(null);
+                    }
+                }
+            });
+        repairAsync();
+    }
+
+    private static boolean isCnAccount() {
+        if (sIsCnAccount == 1) {
+            Context context = ContextUtils.getContext(ContextUtils.FLAG_ALL);
+            if (context == null) {
+                return false;
+            }
+            try {
+                AccountManager accountManager = AccountManager.get(context);
+                Account[] accounts = accountManager.getAccountsByType(ACCOUNT_TYPE);
+                if (accounts.length == 0) {
+                    return false;
+                }
+                String region = accountManager.getUserData(accounts[0], "acc_user_region");
+                sIsCnAccount = "CN".equalsIgnoreCase(region) ? 2 : 3;
+                XposedLog.i(TAG, "account region: " + region);
+            } catch (Throwable t) {
+                XposedLog.w(TAG, "check account region failed", t);
+                return false;
+            }
+        }
+        return sIsCnAccount == 2;
+    }
+
+    private void repairAsync() {
+        Thread thread = new Thread(() -> {
+            for (int i = 0; i < 60; i++) {
+                try {
+                    Context context = ContextUtils.getContext(ContextUtils.FLAG_ALL);
+                    if (context == null || !isCnAccount()) {
+                        Thread.sleep(2000);
+                        continue;
+                    }
+                    Account[] accounts = AccountManager.get(context).getAccountsByType(ACCOUNT_TYPE);
+                    if (accounts.length == 0) {
+                        XposedLog.i(TAG, "no xiaomi account, skip repair");
+                        return;
+                    }
+                    Account account = accounts[0];
+                    ContentResolver.setIsSyncable(account, AUTHORITY, 1);
+                    ContentResolver.setSyncAutomatically(account, AUTHORITY, true);
+                    Bundle extras = new Bundle();
+                    extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
+                    extras.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
+                    ContentResolver.requestSync(account, AUTHORITY, extras);
+                    XposedLog.i(TAG, "gallery sync state repaired");
+                    return;
+                } catch (Throwable t) {
+                    try {
+                        Thread.sleep(2000);
+                    } catch (InterruptedException ignored) {
+                        return;
+                    }
+                }
+            }
+            XposedLog.w(TAG, "repair timeout, give up");
+        });
+        thread.setDaemon(true);
+        thread.start();
+    }
+}


### PR DESCRIPTION
## 问题

国际版（IS_INTERNATIONAL_BUILD=true）ROM 上，CloudService 在每次应用云端配置时都会**无条件**执行相册同步终止逻辑（ServiceTerminatedHelper）：

- `ContentResolver.setIsSyncable(gallery, 0)`
- `ContentResolver.setSyncAutomatically(gallery, false)`

这是为海外账号相册云同步下线（2023-05-31 截止）而设计的。但**中国区账号的相册云服务仍然有效**，在国际版 ROM（如 xiaomi.eu）上登录中国区账号时，配合相册选择小米云备份，设置里能看到开关，却永远卡在「正在请求」——因为同步框架里的 syncable 被反复置 0，请求从未真正发出。

## 方案

新增 `RestoreGallerySync`（作用于 com.miui.cloudservice），在以下两个条件同时满足时自动生效，无需额外开关：

1. 用户已在相册将备份服务器选为小米云（`gallery_backup_server == 1`）
2. 小米账号注册区域为 CN（读取 `acc_user_region`，非 CN 账号完全保持原行为）

生效后：

- 拦截 CloudService 对相册 authority 的 `setIsSyncable(0)` / `setSyncAutomatically(false)` 写入
- CloudService 启动时主动修复状态（syncable=1、自动同步开启、请求一次同步）

## 测试

- 设备：myron，xiaomi.eu（基于 OS3.0.308.0.WPMCNXM），中国区账号
- 修复前：`dumpsys content` 中 `com.miui.gallery.cloud.provider` syncable=0，历史同步次数 0
- 修复后：syncable=1，同步多次 `USER SUCCESS`，云端 3800+ 条数据完整拉回，缩略图与原图正常下载
- 其他同步项（联系人/短信/便签/录音等）不受影响

## 兼容性说明

- 仅 hook `ContentResolver.setIsSyncable/setSyncAutomatically` 两个 AOSP 稳定 API，不涉及混淆类名，对 CloudService 版本变化稳健
- 账号区域检查带缓存，读取失败默认不干预
