### PR TITLE
fix: adapt hooks to HyperOS 3.3 (Android 17)

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -40,6 +40,10 @@ jobs:
       )
     runs-on: macos-latest
     name: Build App
+    permissions:
+      contents: read
+      # Needed so GITHUB_TOKEN may read this repository's own Maven packages.
+      packages: read
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
@@ -76,6 +80,19 @@ jobs:
         run: |
           ./gradlew assembleCanary
           echo "IS_DEBUG=false" >> $GITHUB_ENV
+
+      # settings.gradle.kts needs credentials for the GitHub Packages repository on every
+      # build, but "Create Sign File" only exports GIT_ACTOR / GIT_TOKEN for pushes to
+      # main, so pull request builds always failed with "Missing GitHub credentials".
+      # The package lives in this same repository, so the automatic GITHUB_TOKEN can read
+      # it with the packages: read permission declared above. That token is also handed to
+      # pull requests from forks, where the GIT_TOKEN secret is unavailable by design.
+      - name: Provide GitHub Packages credentials
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          echo "GIT_ACTOR=${{ github.actor }}" >> $GITHUB_ENV
+          echo "GIT_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
       - name: Build with Gradle (Debug)
         if: github.event_name == 'pull_request'

--- a/library/core/src/main/java/com/sevtinge/hyperceiler/utils/PackagesUtils.java
+++ b/library/core/src/main/java/com/sevtinge/hyperceiler/utils/PackagesUtils.java
@@ -212,6 +212,13 @@ public class PackagesUtils {
         mainIntent.setAction(Intent.ACTION_SEND);
         mainIntent.putExtra(Intent.EXTRA_TEXT, "HyperCeiler is the best!");
         mainIntent.setType("*/*");
+        // CleanShareMenu hooks queryIntentActivitiesInternal and strips every already
+        // selected package from ACTION_SEND results. Without the bypass extra the picker
+        // asks the same question through the same hook, so apps that only declare
+        // ACTION_SEND (and no ACTION_VIEW filter matching the queries above) disappear
+        // from the picker as soon as they are selected -- they cannot be reviewed or
+        // deselected again. The three ACTION_VIEW queries already set this extra.
+        mainIntent.putExtra("HyperCeiler", true);
         List<ResolveInfo> packs4 = pm.queryIntentActivities(mainIntent, PackageManager.MATCH_ALL);
 
         packs.addAll(packs2);

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/Others/VariousThirdApps.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/Others/VariousThirdApps.java
@@ -94,9 +94,13 @@ public class VariousThirdApps extends BaseLoad {
         initMusicHooks();
     }
 
+    /** How many causes to walk before giving up, so a self-referential chain cannot loop. */
+    private static final int MAX_CAUSE_DEPTH = 16;
+
     /** True when a throwable (or one of its causes) is the runtime refusing a final write. */
     private static boolean isFinalFieldRejection(Throwable t) {
-        for (Throwable current = t; current != null; current = current.getCause()) {
+        Throwable current = t;
+        for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
             if (current instanceof IllegalAccessException) {
                 return true;
             }
@@ -104,9 +108,7 @@ public class VariousThirdApps extends BaseLoad {
             if (message != null && message.contains("static final")) {
                 return true;
             }
-            if (current.getCause() == current) {
-                break;
-            }
+            current = current.getCause();
         }
         return false;
     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/Others/VariousThirdApps.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/Others/VariousThirdApps.java
@@ -76,12 +76,39 @@ public class VariousThirdApps extends BaseLoad {
                 setStaticObjectField(mBuild, "DEVICE", "caiman");
                 XposedLog.d("GoogleQuickSearchBox", "Spoofed device info to Pixel 9 Pro success");
             } catch (Throwable e) {
-                XposedLog.e("GoogleQuickSearchBox", "Failed to spoof device info: " + e.getMessage());
+                // android.os.Build's fields are public static final. ART used to allow a
+                // reflective write, but Android 17 rejects it, and clearing the FINAL bit
+                // in Field.accessFlags does not help either because finality is enforced
+                // below that mirror. There is no pure-Java way to spoof these fields on
+                // this release, so report it as a warning rather than an error.
+                if (isFinalFieldRejection(e)) {
+                    XposedLog.w("GoogleQuickSearchBox",
+                        "Build field spoofing is not supported on this Android version: " + e.getMessage());
+                } else {
+                    XposedLog.e("GoogleQuickSearchBox", "Failed to spoof device info: " + e.getMessage());
+                }
             }
             return;
         }
 
         initMusicHooks();
+    }
+
+    /** True when a throwable (or one of its causes) is the runtime refusing a final write. */
+    private static boolean isFinalFieldRejection(Throwable t) {
+        for (Throwable current = t; current != null; current = current.getCause()) {
+            if (current instanceof IllegalAccessException) {
+                return true;
+            }
+            String message = current.getMessage();
+            if (message != null && message.contains("static final")) {
+                return true;
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+        }
+        return false;
     }
 
     private void initInputMethodHooks() {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/Others/VariousThirdApps.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/Others/VariousThirdApps.java
@@ -50,6 +50,9 @@ public class VariousThirdApps extends BaseLoad {
     private static final String XIAOMI_BAIDU_PACKAGE = "com.baidu.input_mi";
     private static final String BAIDU_PACKAGE = "com.baidu.input";
 
+    /** How many causes to walk before giving up, so a self-referential chain cannot loop. */
+    private static final int MAX_CAUSE_DEPTH = 16;
+
     private static Set<String> sEnabledInputMethodPackages = Collections.emptySet();
 
     private String mPackageName;
@@ -93,9 +96,6 @@ public class VariousThirdApps extends BaseLoad {
 
         initMusicHooks();
     }
-
-    /** How many causes to walk before giving up, so a self-referential chain cannot loop. */
-    private static final int MAX_CAUSE_DEPTH = 16;
 
     /** True when a throwable (or one of its causes) is the runtime refusing a final write. */
     private static boolean isFinalFieldRejection(Throwable t) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SystemUI/SystemUIB.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/app/SystemUI/SystemUIB.java
@@ -65,6 +65,7 @@ import com.sevtinge.hyperceiler.libhook.rules.systemui.lockscreen.KeepNotificati
 import com.sevtinge.hyperceiler.libhook.rules.systemui.lockscreen.LockScreenDoubleTapToSleep;
 import com.sevtinge.hyperceiler.libhook.rules.systemui.lockscreen.NotificationShowOnKeyguard;
 import com.sevtinge.hyperceiler.libhook.rules.systemui.lockscreen.ScramblePIN;
+import com.sevtinge.hyperceiler.libhook.rules.systemui.navigation.HideGestureLine;
 import com.sevtinge.hyperceiler.libhook.rules.systemui.navigation.RotationButtonB;
 import com.sevtinge.hyperceiler.libhook.rules.systemui.other.AutoSEffSwitchForSystemUi;
 import com.sevtinge.hyperceiler.libhook.rules.systemui.other.BrightnessPct;
@@ -170,6 +171,13 @@ public class SystemUIB extends BaseLoad {
         initHook(HideStrongToast.INSTANCE, PrefsBridge.getBoolean("system_ui_status_bar_hide_smart_strong_toast"));
 
         // 导航栏
+        // Hides the drawn gesture line only. The launcher side (HideNavigationBar) is not
+        // registered for OS 3 because driving NavStubView#mHideGestureLine resizes the
+        // gesture hot space and breaks swipe navigation and Circle to Search.
+        // Skipped when the user customizes the line themselves, so their thickness and
+        // colour win instead of being overwritten here.
+        initHook(new HideGestureLine(), PrefsBridge.getBoolean("system_ui_hide_navigation_bar")
+            && !PrefsBridge.getBoolean("system_ui_navigation_handle_custom"));
         initHook(RotationButtonB.INSTANCE, PrefsBridge.getStringAsInt("system_framework_other_rotation_button_int", 0) != 0);
 
         // 控制与通知中心

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/appbase/systemframework/ModulePackageTrust.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/appbase/systemframework/ModulePackageTrust.java
@@ -32,6 +32,17 @@ import java.util.List;
 import io.github.libxposed.api.XposedInterface;
 
 public class ModulePackageTrust extends BaseHook {
+    /** Legacy permission backend: shouldGrantPermissionBySignature(AndroidPackage, Permission). */
+    private static final String PERMISSION_SERVICE_IMPL =
+        "com.android.server.pm.permission.PermissionManagerServiceImpl";
+    /**
+     * Android 17 permission backend. The method moved to the new access based policy and gained a
+     * leading MutateStateScope parameter: shouldGrantPermissionBySignature(MutateStateScope,
+     * PackageState, Permission).
+     */
+    private static final String APP_ID_PERMISSION_POLICY =
+        "com.android.server.permission.access.permission.AppIdPermissionPolicy";
+
     private final ArrayList<String> systemPackages = new ArrayList<>();
 
     @Override
@@ -39,18 +50,11 @@ public class ModulePackageTrust extends BaseHook {
     public void init() {
         systemPackages.add(ProjectApi.mAppModulePkg);
 
-        chainAllMethods("com.android.server.pm.permission.PermissionManagerServiceImpl",
-            "shouldGrantPermissionBySignature",
-            new XposedInterface.Hooker() {
-                @Override
-                public Object intercept(XposedInterface.Chain chain) throws Throwable {
-                    String packageName = (String) callMethod(chain.getArg(0), "getPackageName");
-                    if (systemPackages.contains(packageName)) {
-                        return true;
-                    }
-                    return chain.proceed();
-                }
-            });
+        if (findClassIfExists(APP_ID_PERMISSION_POLICY) != null) {
+            hookGrantBySignature(APP_ID_PERMISSION_POLICY, 1);
+        } else {
+            hookGrantBySignature(PERMISSION_SERVICE_IMPL, 0);
+        }
 
         chainAllMethods("com.android.server.pm.PackageManagerServiceUtils",
             "verifySignatures",
@@ -122,5 +126,20 @@ public class ModulePackageTrust extends BaseHook {
         } catch (Throwable t) {
             XposedLog.w(TAG, getPackageName(), t);
         }
+    }
+
+    private void hookGrantBySignature(String className, int packageArgIndex) {
+        chainAllMethods(className, "shouldGrantPermissionBySignature",
+            new XposedInterface.Hooker() {
+                @Override
+                public Object intercept(XposedInterface.Chain chain) throws Throwable {
+                    String packageName =
+                        (String) callMethod(chain.getArg(packageArgIndex), "getPackageName");
+                    if (systemPackages.contains(packageName)) {
+                        return true;
+                    }
+                    return chain.proceed();
+                }
+            });
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/guardprovider/DisableUploadAppListNew.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/guardprovider/DisableUploadAppListNew.java
@@ -38,7 +38,13 @@ public class DisableUploadAppListNew extends BaseHook {
 
     @Override
     protected boolean initDexKit() {
-        mAntiDefraudAppManagerMethod = requiredMember("AntiDefraudAppManager", bridge -> bridge.findMethod(FindMethod.create()
+        // Both anchor strings ("AntiDefraudAppManager" and
+        // "https://flash.sec.miui.com/detect/app") are completely absent from the global
+        // guardprovider on HyperOS 3.3 -- the app-list upload code is not in this package
+        // any more, so there is nothing to hook. Use optionalMember instead of
+        // requiredMember so a miss is skipped quietly rather than throwing and leaving
+        // "Skip hook because initDexKit failed" behind.
+        mAntiDefraudAppManagerMethod = optionalMember("AntiDefraudAppManager", bridge -> bridge.findMethod(FindMethod.create()
             .matcher(MethodMatcher.create()
                 .usingStrings("AntiDefraudAppManager", "https://flash.sec.miui.com/detect/app")
             )).singleOrNull());
@@ -47,6 +53,9 @@ public class DisableUploadAppListNew extends BaseHook {
 
     @Override
     public void init() {
+        if (mAntiDefraudAppManagerMethod == null) {
+            return;
+        }
         com.sevtinge.hyperceiler.libhook.base.BaseHook.hookMethod(mAntiDefraudAppManagerMethod, new IReplaceHook() {
             @Override
             public Object replace(HookParam param) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/home/AnimDurationRatio.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/home/AnimDurationRatio.kt
@@ -25,6 +25,10 @@ import io.github.lingqiqi5211.ezhooktool.core.loadClass
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createHook
 
 object AnimDurationRatio : BaseHook() {
+    // HyperOS 3 moved the launcher helper out of com.miui.home.launcher.common.
+    private const val DEVICE_LEVEL_UTILS_OLD = "com.miui.home.launcher.common.DeviceLevelUtils"
+    private const val DEVICE_LEVEL_UTILS_NEW = "com.miui.home.common.utils.DeviceLevelUtils"
+
     override fun init() {
         var value1 = PrefsBridge.getInt("home_title_animation_speed", 100).toFloat()
         var value2 = PrefsBridge.getInt("home_recent_animation_speed", 100).toFloat()
@@ -38,7 +42,9 @@ object AnimDurationRatio : BaseHook() {
         }
         if (value2 != 100f) {
             value2 /= 100f
-            loadClass("com.miui.home.launcher.common.DeviceLevelUtils").findMethod { name("getDeviceLevelTransitionAnimRatio") }.createHook {
+            val deviceLevelUtils = findClassIfExists(DEVICE_LEVEL_UTILS_NEW)
+                ?: findClassIfExists(DEVICE_LEVEL_UTILS_OLD)
+            deviceLevelUtils?.findMethod { name("getDeviceLevelTransitionAnimRatio") }?.createHook {
                     before {
                         it.result = value2
                     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/home/layout/WorkspacePadding.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/home/layout/WorkspacePadding.java
@@ -37,20 +37,46 @@ public class WorkspacePadding extends HomeBaseHookNew {
 
     @Override
     public void initBase() {
-        mDeviceConfig = findClassIfExists(getPackageVersionCode(getLpparam()) < 600000000 ? DEVICE_CONFIG_NEW : DEVICE_CONFIG_OLD);
+        // The workspace padding getters live on DeviceConfig (old) on some launcher
+        // versions and on DeviceConfigs (new) on others. The original code picked the
+        // class with `versionCode < 600000000 ? NEW : OLD`, which is inverted with respect
+        // to how every other home rule maps versions (@Version(min = 600000000) -> NEW).
+        // On a HyperOS 3.3 launcher (e.g. 750062372) that resolved the old class, where
+        // getWorkspaceCellPadding* no longer exists, so initBase() aborted with
+        // MemberNotFoundException.
+        // Rather than relying on a version number at all, pick whichever class actually
+        // declares the getters. That keeps older launchers on exactly the class they
+        // already worked with, whichever one that is.
+        mDeviceConfig = resolveDeviceConfigClass();
 
-        findAndHookMethod(mDeviceConfig, "Init", Context.class, boolean.class, new IMethodHook() {
+        // Capture a Context for dp2px. The signature differs between versions:
+        //   old class: Init(Context, boolean) / Init(Context, int, boolean)
+        //   new class: init(Context, boolean)  (lower-case first letter)
+        // So hook every overload of either name and take the first Context argument.
+        IMethodHook captureContext = new IMethodHook() {
             @Override
             public void before(HookParam param) {
-                mContext = (Context) param.getArgs()[0];
+                for (Object arg : param.getArgs()) {
+                    if (arg instanceof Context) {
+                        mContext = (Context) arg;
+                        break;
+                    }
+                }
             }
-        });
+        };
+        hookAllMethods(mDeviceConfig, "Init", captureContext);
+        hookAllMethods(mDeviceConfig, "init", captureContext);
 
         if (PrefsBridge.getBoolean("home_layout_workspace_padding_bottom_enable")) {
             findAndHookMethod(mDeviceConfig, "getWorkspaceCellPaddingBottom", new IMethodHook() {
                 @Override
                 public void before(HookParam param) {
-                    param.setResult(DisplayUtils.dp2px(mContext, PrefsBridge.getInt("home_layout_workspace_padding_bottom", 0)));
+                    int dp = PrefsBridge.getInt("home_layout_workspace_padding_bottom", 0);
+                    // Init/init does not necessarily run before the getter, so mContext
+                    // may still be null here
+                    param.setResult(mContext != null
+                        ? DisplayUtils.dp2px(mContext, dp)
+                        : DisplayUtils.dp2px(dp));
                 }
             });
         }
@@ -83,5 +109,35 @@ public class WorkspacePadding extends HomeBaseHookNew {
                 }
             });
         }
+    }
+
+    /**
+     * Picks the DeviceConfig class that actually declares the workspace padding getters.
+     *
+     * Falls back to the version-based choice used elsewhere in the home rules
+     * (>= 600000000 -> DeviceConfigs) if neither class exposes them, so behaviour stays
+     * defined even on a launcher this was never tested against.
+     */
+    private Class<?> resolveDeviceConfigClass() {
+        for (String name : new String[]{DEVICE_CONFIG_NEW, DEVICE_CONFIG_OLD}) {
+            Class<?> clazz = findClassIfExists(name);
+            if (clazz != null && declaresPaddingGetter(clazz)) {
+                return clazz;
+            }
+        }
+        return findClassIfExists(getPackageVersionCode(getLpparam()) >= 600000000
+            ? DEVICE_CONFIG_NEW : DEVICE_CONFIG_OLD);
+    }
+
+    private boolean declaresPaddingGetter(Class<?> clazz) {
+        for (java.lang.reflect.Method method : clazz.getDeclaredMethods()) {
+            String name = method.getName();
+            if (name.equals("getWorkspaceCellPaddingBottom")
+                || name.equals("getWorkspaceCellPaddingTop")
+                || name.equals("getWorkspaceCellPaddingSide")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/securitycenter/app/AddAppManagerEntry.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/securitycenter/app/AddAppManagerEntry.kt
@@ -21,6 +21,7 @@ package com.sevtinge.hyperceiler.libhook.rules.securitycenter.app
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
+import android.provider.Settings
 import android.view.Menu
 import android.view.MenuItem
 import com.sevtinge.hyperceiler.libhook.R
@@ -51,10 +52,11 @@ object AddAppManagerEntry : BaseHook() {
                     val menuItem = (it.args[0] as Menu).add(
                         idIdMiuixActionEndMenuGroup, 0, 0, R.string.security_center_aosp_app_manager
                     )
-                    menuItem.intent = Intent(Intent.ACTION_MAIN).setClassName(
-                        "com.android.settings",
-                        "com.android.settings.applications.ManageApplications"
-                    )
+                    // HyperOS 3 moved com.android.settings.applications.ManageApplications into
+                    // the manageapplications subpackage, so target the public intent action
+                    // instead of a class name that keeps moving between releases.
+                    menuItem.intent = Intent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
+                        .setPackage("com.android.settings")
                     menuItem.setIcon(idDrawableIconSettings)
                     menuItem.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/securitycenter/other/RemoveSIMLockSuccessDialog.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/securitycenter/other/RemoveSIMLockSuccessDialog.kt
@@ -22,13 +22,25 @@ package com.sevtinge.hyperceiler.libhook.rules.securitycenter.other
 import android.app.Activity
 import android.os.Bundle
 
+import com.sevtinge.hyperceiler.common.log.XposedLog
 import com.sevtinge.hyperceiler.libhook.base.BaseHook
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.beforeHookMethod
 
 object RemoveSIMLockSuccessDialog : BaseHook() {
+    private const val SUCCESS_DIALOG = "com.miui.simlock.activity.SuccessDialogActivity"
+
     @Throws(NoSuchMethodException::class)
     override fun init() {
-        "com.miui.simlock.activity.SuccessDialogActivity".beforeHookMethod("onCreate", Bundle::class.java) { param ->
+        // SIM lock only exists in the Chinese Security Center build; the whole
+        // com.miui.simlock package is absent from the global one
+        // (MIUISecurityCenterGlobal). Hooking it directly throws ClassNotFoundError and
+        // leaves a meaningless "Hook Failed" in the log, so check the class first.
+        if (findClassIfExists(SUCCESS_DIALOG) == null) {
+            XposedLog.d(TAG, packageName, "$SUCCESS_DIALOG not present, skip (non-CN SecurityCenter)")
+            return
+        }
+
+        SUCCESS_DIALOG.beforeHookMethod("onCreate", Bundle::class.java) { param ->
             (param.thisObject as Activity).finish()
         }
     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/DisableThermal.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/DisableThermal.kt
@@ -23,11 +23,19 @@ import io.github.lingqiqi5211.ezhooktool.core.findAllMethods
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createBeforeHooks
 
 object DisableThermal : BaseHook() {
+    // Android 17 moved the service into its own package and renamed the dispatch method.
+    private const val SERVICE_OLD = "com.android.server.power.ThermalManagerService"
+    private const val SERVICE_NEW = "com.android.server.power.thermal.ThermalManagerService"
+
     override fun init() {
-        findClass("com.android.server.power.ThermalManagerService").findAllMethods { name("postEventListener") }
+        val service = findClassIfExists(SERVICE_NEW) ?: findClassIfExists(SERVICE_OLD) ?: return
+        service.findAllMethods { name("postEventListener") }
             .createBeforeHooks {
                 it.result = null
             }
-
+        service.findAllMethods { name("postEventListenerLocked") }
+            .createBeforeHooks {
+                it.result = null
+            }
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemsettings/MoreNotificationSettings.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemsettings/MoreNotificationSettings.java
@@ -108,8 +108,13 @@ public class MoreNotificationSettings extends BaseHook {
                         param.setResult(null);// 关闭面板
                         ClassLoader cl = context.getClassLoader();
                         Class<?> dependencyClass = findClass("com.android.systemui.Dependency", cl);
-                        Class<?> modalControllerClass = findClass(
-                            "com.android.systemui.statusbar.notification.modal.ModalController", cl);
+                        // HyperOS 3 exposes the controller through its interface instead.
+                        Class<?> modalControllerClass = findClassIfExists(
+                            "com.android.systemui.statusbar.notification.modal.IModalController", cl);
+                        if (modalControllerClass == null) {
+                            modalControllerClass = findClass(
+                                "com.android.systemui.statusbar.notification.modal.ModalController", cl);
+                        }
                         Object modalController = callStaticMethod(dependencyClass, "get", modalControllerClass);
                         callMethod(modalController, "animExitModelCollapsePanels");
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemsettings/MoreNotificationSettings.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemsettings/MoreNotificationSettings.java
@@ -34,7 +34,10 @@ import io.github.lingqiqi5211.ezhooktool.xposed.common.HookParam;
 
 public class MoreNotificationSettings extends BaseHook {
 
-    private static final String[] VISIBLE_PREF_KEYS = {"importance", "badge", "allow_keyguard"};
+    // "setting_badge" is what miui_channel_notification_settings.xml calls the badge checkbox on
+    // HyperOS 3; "badge" is kept for the builds that still use the AOSP key.
+    private static final String[] VISIBLE_PREF_KEYS =
+        {"importance", "badge", "setting_badge", "allow_keyguard"};
 
     @Override
     public void init() {
@@ -108,13 +111,8 @@ public class MoreNotificationSettings extends BaseHook {
                         param.setResult(null);// 关闭面板
                         ClassLoader cl = context.getClassLoader();
                         Class<?> dependencyClass = findClass("com.android.systemui.Dependency", cl);
-                        // HyperOS 3 exposes the controller through its interface instead.
-                        Class<?> modalControllerClass = findClassIfExists(
-                            "com.android.systemui.statusbar.notification.modal.IModalController", cl);
-                        if (modalControllerClass == null) {
-                            modalControllerClass = findClass(
-                                "com.android.systemui.statusbar.notification.modal.ModalController", cl);
-                        }
+                        Class<?> modalControllerClass = findClass(
+                            "com.android.systemui.statusbar.notification.modal.ModalController", cl);
                         Object modalController = callStaticMethod(dependencyClass, "get", modalControllerClass);
                         callMethod(modalController, "animExitModelCollapsePanels");
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/navigation/HideGestureLine.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/navigation/HideGestureLine.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of HyperCeiler.
+
+ * HyperCeiler is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+ * Copyright (C) 2023-2026 HyperCeiler Contributions
+ */
+package com.sevtinge.hyperceiler.libhook.rules.systemui.navigation;
+
+import com.sevtinge.hyperceiler.libhook.base.BaseHook;
+
+/**
+ * Hides the drawn gesture line without touching gesture behaviour.
+ *
+ * <p>The launcher side of "hide gesture line" (HideNavigationBar) works on
+ * NavStubView#mHideGestureLine, but that field feeds isImmersive, getHotSpaceHeight,
+ * isNeedAdjustTouchArea and canPerformQuickSwitch, and NavStubView#setHideGestureLine also
+ * relayouts the gesture window. Driving it therefore changes the size of the gesture hot
+ * space, which breaks swipe navigation and the long press that starts Circle to Search.
+ *
+ * <p>The line itself is drawn by SystemUI from dimen/navigation_handle_radius using
+ * color/navigation_bar_home_handle_{light,dark}_color, the same resources the "customize
+ * gesture line" option overrides. Only the colours are replaced here: a fully transparent
+ * handle cannot be seen, while its size and therefore every touch region stay exactly as
+ * the system computed them.
+ *
+ * <p>dimen/navigation_handle_radius is deliberately left alone. Forcing it to zero also
+ * hides the line, but it feeds hit testing as well as painting, and a zero sized handle
+ * stops the long press that starts Circle to Search (measured on HyperOS 3.3). Keeping the
+ * stock radius keeps that gesture working.
+ */
+public class HideGestureLine extends BaseHook {
+    private static final int TRANSPARENT = 0;
+
+    @Override
+    public void init() {
+        setObjectReplacement("com.android.systemui", "color",
+            "navigation_bar_home_handle_dark_color", TRANSPARENT);
+        setObjectReplacement("com.android.systemui", "color",
+            "navigation_bar_home_handle_light_color", TRANSPARENT);
+    }
+}

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/plugin/NewPluginHelperKt.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/plugin/NewPluginHelperKt.kt
@@ -72,8 +72,10 @@ object NewPluginHelperKt : BaseHook() {
                     onPluginLoaded(PluginFactory(it.thisObject).also { isLoad ->
                         isLoad.pluginCtxRef = WeakReference(wrapper)
                     })
-                }.onFailure {
-                    XposedLog.e(TAG, lpparam.packageName, "Failed to create plugin context.")
+                }.onFailure { throwable ->
+                    // Include the throwable itself, otherwise this only leaves behind a
+                    // log line with no clue about what actually failed
+                    XposedLog.e(TAG, lpparam.packageName, "Failed to create plugin context.", throwable)
                     return@createAfterHook
                 }
             }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/HideStatusBarBeforeScreenshot.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/HideStatusBarBeforeScreenshot.java
@@ -35,6 +35,8 @@ public class HideStatusBarBeforeScreenshot extends BaseHook {
 
     private static final String COLLAPSED_STATUS_BAR_CLASS =
         "com.android.systemui.statusbar.phone.MiuiCollapsedStatusBarFragment";
+    private static final String PHONE_STATUS_BAR_VIEW_CLASS =
+        "com.android.systemui.statusbar.phone.MiuiPhoneStatusBarView";
     private static final String ACTION_TAKE_SCREENSHOT = "miui.intent.TAKE_SCREENSHOT";
     private static final String EXTRA_IS_FINISHED = "IsFinished";
     private static final String HOT_RELOAD_VIEW_KEY =
@@ -47,11 +49,25 @@ public class HideStatusBarBeforeScreenshot extends BaseHook {
         if (restoredView != null) {
             registerScreenshotReceiver(restoredView);
         }
-        hookAllMethods(COLLAPSED_STATUS_BAR_CLASS, "onViewCreated", new IMethodHook() {
+        if (findClassIfExists(COLLAPSED_STATUS_BAR_CLASS) != null) {
+            hookAllMethods(COLLAPSED_STATUS_BAR_CLASS, "onViewCreated", new IMethodHook() {
+                @Override
+                public void after(HookParam param) {
+                    View view = (View) param.getArgs()[0];
+                    registerScreenshotReceiver(view);
+                }
+            });
+            return;
+        }
+
+        // HyperOS 3 replaced the fragment based status bar with the HomeStatusBar view binder
+        // pipeline, so MiuiCollapsedStatusBarFragment no longer exists and the hook above never
+        // fired. The fragment root was always the inflated R.layout.status_bar, which is the same
+        // MiuiPhoneStatusBarView instance obtained here, so hiding it keeps the old behaviour.
+        hookAllMethods(PHONE_STATUS_BAR_VIEW_CLASS, "onFinishInflate", new IMethodHook() {
             @Override
             public void after(HookParam param) {
-                View view = (View) param.getArgs()[0];
-                registerScreenshotReceiver(view);
+                registerScreenshotReceiver((View) param.getThisObject());
             }
         });
     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/HideVoWiFiIcon.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/HideVoWiFiIcon.kt
@@ -21,7 +21,9 @@ package com.sevtinge.hyperceiler.libhook.rules.systemui.statusbar.icon.all
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge
 import com.sevtinge.hyperceiler.libhook.base.BaseHook
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.setBooleanField
+import io.github.lingqiqi5211.ezhooktool.core.findMethod
 import io.github.lingqiqi5211.ezhooktool.core.loadClass
+import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createAfterHook
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createHook
 
 object HideVoWiFiIcon : BaseHook() {
@@ -33,11 +35,33 @@ object HideVoWiFiIcon : BaseHook() {
     }
 
     override fun init() {
-        loadClass($$"com.miui.interfaces.IOperatorCustomizedPolicy$OperatorConfig").constructors[0].createHook {
-            after {
-                it.thisObject.setBooleanField("hideVowifi", hideVoWifi)
-                it.thisObject.setBooleanField("hideVolte", hideVolte)
+        val operatorConfig = loadClass($$"com.miui.interfaces.IOperatorCustomizedPolicy$OperatorConfig")
+
+        // OS 2.x / OS 3.0: OperatorConfig still has an <init>, so keep the original
+        // constructor hook.
+        val constructors = operatorConfig.declaredConstructors
+        if (constructors.isNotEmpty()) {
+            constructors[0].createHook {
+                after { applyOperatorConfig(it.thisObject) }
             }
+            return
         }
+
+        // HyperOS 3.3 (Android 17): R8 inlined OperatorConfig's constructor into
+        // MiuiOperatorCustomizedPolicy#getMiuiOperatorConfig -- the dex only contains
+        // new-instance plus iput, with no <init> left at all, so constructors[0]
+        // throws ArrayIndexOutOfBoundsException(length=0). Hook the method that now
+        // holds the construction instead and overwrite the fields on its result,
+        // which has the same effect as the old constructor hook.
+        loadClass("com.android.systemui.MiuiOperatorCustomizedPolicy")
+            .findMethod { name("getMiuiOperatorConfig") }
+            .createAfterHook { param ->
+                applyOperatorConfig(param.result ?: return@createAfterHook)
+            }
+    }
+
+    private fun applyOperatorConfig(config: Any) {
+        config.setBooleanField("hideVowifi", hideVoWifi)
+        config.setBooleanField("hideVolte", hideVolte)
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/HideVoWiFiIcon.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/HideVoWiFiIcon.kt
@@ -55,13 +55,12 @@ object HideVoWiFiIcon : BaseHook() {
         // which has the same effect as the old constructor hook.
         loadClass("com.android.systemui.MiuiOperatorCustomizedPolicy")
             .findMethod { name("getMiuiOperatorConfig") }
-            .createAfterHook { param ->
-                applyOperatorConfig(param.result ?: return@createAfterHook)
-            }
+            .createAfterHook { param -> applyOperatorConfig(param.result) }
     }
 
-    private fun applyOperatorConfig(config: Any) {
-        config.setBooleanField("hideVowifi", hideVoWifi)
-        config.setBooleanField("hideVolte", hideVolte)
+    private fun applyOperatorConfig(config: Any?) {
+        val target = config ?: return
+        target.setBooleanField("hideVowifi", hideVoWifi)
+        target.setBooleanField("hideVolte", hideVolte)
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/StatusBarIcon.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/StatusBarIcon.java
@@ -79,7 +79,7 @@ public class StatusBarIcon extends BaseHook {
 
     private void trySetBlockList(Class<?> clazz, String fieldName, List<String> value) {
         try {
-            com.sevtinge.hyperceiler.libhook.base.BaseHook.setStaticObjectField(clazz, fieldName, value);
+            BaseHook.setStaticObjectField(clazz, fieldName, value);
         } catch (Throwable t) {
             XposedLog.w(TAG, getPackageName(),
                 "skip writing back " + fieldName + " (already mutated in place): " + t.getMessage());

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/StatusBarIcon.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/icon/all/StatusBarIcon.java
@@ -18,6 +18,7 @@
  */
 package com.sevtinge.hyperceiler.libhook.rules.systemui.statusbar.icon.all;
 
+import com.sevtinge.hyperceiler.common.log.XposedLog;
 import com.sevtinge.hyperceiler.libhook.base.BaseHook;
 import com.sevtinge.hyperceiler.common.utils.PrefsBridge;
 
@@ -64,8 +65,25 @@ public class StatusBarIcon extends BaseHook {
         setIcon(PrefsBridge.getStringAsInt("system_ui_status_bar_icon_tv", 0), "tv", statusBarList, ctrlCenterList);
         setIcon(PrefsBridge.getStringAsInt("system_ui_status_bar_icon_wireless_headset", 0), "wireless_headset", statusBarList, ctrlCenterList);
 
-        com.sevtinge.hyperceiler.libhook.base.BaseHook.setStaticObjectField(mMiuiIconManagerUtils, "RIGHT_BLOCK_LIST", statusBarList);
-        com.sevtinge.hyperceiler.libhook.base.BaseHook.setStaticObjectField(mMiuiIconManagerUtils, "CONTROL_CENTER_BLOCK_LIST", ctrlCenterList);
+        // setIcon() already mutated these two ArrayList instances in place, and consumers
+        // read the static field directly (sget), so writing the field back is only kept
+        // for compatibility with the old "the field may be swapped for a new list"
+        // behaviour -- it is not required.
+        // On HyperOS 3.3 (Android 17) RIGHT_BLOCK_LIST / CONTROL_CENTER_BLOCK_LIST are
+        // public static final, so a reflective write throws IllegalAccessException. Left
+        // unguarded that exception aborts init() and also drops the
+        // CONTROL_CENTER_BLOCK_LIST write below it.
+        trySetBlockList(mMiuiIconManagerUtils, "RIGHT_BLOCK_LIST", statusBarList);
+        trySetBlockList(mMiuiIconManagerUtils, "CONTROL_CENTER_BLOCK_LIST", ctrlCenterList);
+    }
+
+    private void trySetBlockList(Class<?> clazz, String fieldName, List<String> value) {
+        try {
+            com.sevtinge.hyperceiler.libhook.base.BaseHook.setStaticObjectField(clazz, fieldName, value);
+        } catch (Throwable t) {
+            XposedLog.w(TAG, getPackageName(),
+                "skip writing back " + fieldName + " (already mutated in place): " + t.getMessage());
+        }
     }
 
     private void setIcon(int value, String name, List<String> statusBarList, List<String> controlList){

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobilePublicHookV.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobilePublicHookV.kt
@@ -36,6 +36,7 @@ import com.sevtinge.hyperceiler.libhook.utils.api.DeviceHelper.System.isMoreSmal
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.StateFlowHelper.newReadonlyStateFlow
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.StateFlowHelper.setStateFlowValue
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui.MobileClass.miuiCellularIconVM
+import com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui.MobileClass.miuiMobileIconBinder
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui.MobilePrefs.card1
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui.MobilePrefs.card2
 import com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui.MobilePrefs.hideIndicator
@@ -48,9 +49,11 @@ import com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui.MobileViewHelper.
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.getObjectFieldAs
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.hookAllConstructors
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.setObjectField
+import io.github.lingqiqi5211.ezhooktool.core.callMethodAs
+import io.github.lingqiqi5211.ezhooktool.core.findMethod
 import io.github.lingqiqi5211.ezhooktool.core.loadClass
 import io.github.lingqiqi5211.ezhooktool.xposed.EzXposed
-import io.github.lingqiqi5211.ezhooktool.xposed.common.HookParam
+import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createBeforeHook
 import java.util.concurrent.ConcurrentHashMap
 
 class MobilePublicHookV : BaseHook() {
@@ -62,6 +65,12 @@ class MobilePublicHookV : BaseHook() {
 
     private val visibilityFlows = ConcurrentHashMap<Int, Any>()
 
+    /**
+     * MiuiCellularIconVM instances (by identityHashCode) already handled on the bind
+     * path, so the flows are not replaced again for every location.
+     */
+    private val appliedViewModels = ConcurrentHashMap.newKeySet<Int>()
+
     @Volatile
     private var broadcastRegistered = false
 
@@ -72,58 +81,107 @@ class MobilePublicHookV : BaseHook() {
     override fun init() {
         restoreVisibilityFlowsAfterHotReload()
 
-        miuiCellularIconVM.hookAllConstructors {
-            after { param ->
-                val cellularIcon = param.thisObject
-                val mobileIconInteractor = param.args[2] ?: return@after
-                val subId = mobileIconInteractor.getObjectFieldAs<Int>("subId")
-                val isVisible = createVisibilityFlow()
-
-                when {
-                    // 信号显示逻辑
-                    signalShowMode >= 1 -> {
-                        cellularIcon.setObjectField("isVisible", isVisible)
-                        trackVisibilityFlow(subId, isVisible)
-                        refreshVisibility(subId, isVisible)
-                        registerReceiver(EzXposed.appContext)
-                    }
-                    // 双排信号（signalShowMode == 0 且未隐藏卡）
-                    isEnableDouble && !(card1 || card2) -> {
-                        cellularIcon.setObjectField("isVisible", isVisible)
-                        trackVisibilityFlow(subId, isVisible)
-                        val slotIndex = SubscriptionManager.getSlotIndex(subId)
-                        val shouldShow = !MobileViewHelper.isAirplaneModeOn() &&
-                            (MobileViewHelper.isSingleSimMode() || slotIndex == 0)
-                        updateVisibility(isVisible, shouldShow)
-                        registerReceiver(EzXposed.appContext)
-                    }
-                    // 隐藏指定卡
-                    else -> {
-                        val slotIndex = SubscriptionManager.getSlotIndex(subId)
-                        if ((card1 && slotIndex == 0) || (card2 && slotIndex == 1)) {
-                            cellularIcon.setObjectField("isVisible", isVisible)
-                        }
-                    }
-                }
-
-                if (hideIndicator) {
-                    cellularIcon.setObjectField("inOutVisible", newReadonlyStateFlow(false))
-                }
-                if (hideRoaming) {
-                    // 新版 MiuiCellularIconVM 中 *RoamVisible 字段类型为
-                    // FlowKt__ZipKt$combine$$inlined$combineUnsafe$FlowKt__ZipKt$1
-                    // （combine 产生的匿名 Flow），直接 setObjectField 会抛
-                    // IllegalArgumentException。先尝试旧版直接替换 StateFlow，
-                    // 失败则改为劫持其内部 $transform$inlined$1 lambda 让合并结果恒为 false。
-                    forceRoamHidden(cellularIcon, "smallRoamVisible")
-                    forceRoamHidden(cellularIcon, "mobileRoamVisible")
-                }
-                if (!isMoreSmallVersion(200, 2f)) {
-                    updateIconState(param, "smallHdVisible", "system_ui_status_bar_icon_small_hd")
-                    updateIconState(param, "volteVisibleCn", "system_ui_status_bar_icon_big_hd")
-                    updateIconState(param, "volteVisibleGlobal", "system_ui_status_bar_icon_big_hd")
+        // OS 2.x / OS 3.0: MiuiCellularIconVM still has an <init>, so keep the original
+        // constructor hook.
+        if (miuiCellularIconVM.declaredConstructors.isNotEmpty()) {
+            miuiCellularIconVM.hookAllConstructors {
+                after { param ->
+                    val mobileIconInteractor = param.args[2] ?: return@after
+                    applyToViewModel(param.thisObject, mobileIconInteractor)
                 }
             }
+            return
+        }
+
+        // HyperOS 3.3 (Android 17): R8 inlined MiuiCellularIconVM's constructor away, so
+        // the dex has no <init> left (all 22 members are getters and the fields became
+        // public). hookAllConstructors then silently matches zero targets -- no
+        // exception, nothing in the log -- so the second SIM's isVisible is never set to
+        // false and the dual-row signal gets drawn once per mobile view, which shows up
+        // as "the dual row is rendered twice".
+        // Handle it in MiuiMobileIconBinder#bind instead: its args[2] is declared as the
+        // MiuiMobileIconViewModel interface but is a MiuiCellularIconVM at runtime, and a
+        // before-hook runs prior to the official bind collecting these flows, so the
+        // replacement happens at the same point in time as the constructor hook did.
+        miuiMobileIconBinder.findMethod { name("bind") }
+            .createBeforeHook { param ->
+                val cellularIcon = param.args[2] ?: return@createBeforeHook
+                // bind is called once per location (status bar / keyguard / control
+                // center) for the same VM, so only the first call is handled. Register
+                // the VM only after it succeeded, otherwise a single failure would make
+                // this VM be skipped forever.
+                val viewModelKey = System.identityHashCode(cellularIcon)
+                if (viewModelKey in appliedViewModels) return@createBeforeHook
+                val mobileIconInteractor = runCatching {
+                    cellularIcon.callMethodAs<Any>("getOriginIconInteractor")
+                }.getOrNull() ?: return@createBeforeHook
+                applyToViewModel(cellularIcon, mobileIconInteractor)
+                appliedViewModels.add(viewModelKey)
+            }
+    }
+
+    /**
+     * Resolves the subId.
+     *
+     * On the old constructor-hook path args[2] is the MIUI-side interactor, which has a
+     * plain subId field. On HyperOS 3.3 (Android 17) the object reached through bind is a
+     * MobileIconInteractorImpl, where the field was renamed to subscriptionId (with a
+     * matching getSubscriptionId()), so reading subId throws MemberNotFoundException.
+     * The old name is tried first so behaviour on older versions is unchanged.
+     */
+    private fun resolveSubId(interactor: Any): Int? =
+        runCatching { interactor.getObjectFieldAs<Int>("subId") }.getOrNull()
+            ?: runCatching { interactor.getObjectFieldAs<Int>("subscriptionId") }.getOrNull()
+            ?: runCatching { interactor.callMethodAs<Int>("getSubscriptionId") }.getOrNull()
+
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.READ_PHONE_STATE])
+    private fun applyToViewModel(cellularIcon: Any, mobileIconInteractor: Any) {
+        val subId = resolveSubId(mobileIconInteractor) ?: return
+        val isVisible = createVisibilityFlow()
+
+        when {
+            // 信号显示逻辑
+            signalShowMode >= 1 -> {
+                cellularIcon.setObjectField("isVisible", isVisible)
+                trackVisibilityFlow(subId, isVisible)
+                refreshVisibility(subId, isVisible)
+                registerReceiver(EzXposed.appContext)
+            }
+            // 双排信号（signalShowMode == 0 且未隐藏卡）
+            isEnableDouble && !(card1 || card2) -> {
+                cellularIcon.setObjectField("isVisible", isVisible)
+                trackVisibilityFlow(subId, isVisible)
+                val slotIndex = SubscriptionManager.getSlotIndex(subId)
+                val shouldShow = !MobileViewHelper.isAirplaneModeOn() &&
+                    (MobileViewHelper.isSingleSimMode() || slotIndex == 0)
+                updateVisibility(isVisible, shouldShow)
+                registerReceiver(EzXposed.appContext)
+            }
+            // 隐藏指定卡
+            else -> {
+                val slotIndex = SubscriptionManager.getSlotIndex(subId)
+                if ((card1 && slotIndex == 0) || (card2 && slotIndex == 1)) {
+                    cellularIcon.setObjectField("isVisible", isVisible)
+                }
+            }
+        }
+
+        if (hideIndicator) {
+            cellularIcon.setObjectField("inOutVisible", newReadonlyStateFlow(false))
+        }
+        if (hideRoaming) {
+            // 新版 MiuiCellularIconVM 中 *RoamVisible 字段类型为
+            // FlowKt__ZipKt$combine$$inlined$combineUnsafe$FlowKt__ZipKt$1
+            // （combine 产生的匿名 Flow），直接 setObjectField 会抛
+            // IllegalArgumentException。先尝试旧版直接替换 StateFlow，
+            // 失败则改为劫持其内部 $transform$inlined$1 lambda 让合并结果恒为 false。
+            forceRoamHidden(cellularIcon, "smallRoamVisible")
+            forceRoamHidden(cellularIcon, "mobileRoamVisible")
+        }
+        if (!isMoreSmallVersion(200, 2f)) {
+            updateIconState(cellularIcon, "smallHdVisible", "system_ui_status_bar_icon_small_hd")
+            updateIconState(cellularIcon, "volteVisibleCn", "system_ui_status_bar_icon_big_hd")
+            updateIconState(cellularIcon, "volteVisibleGlobal", "system_ui_status_bar_icon_big_hd")
         }
     }
 
@@ -326,10 +384,10 @@ class MobilePublicHookV : BaseHook() {
         BaseHook.putHotReloadRuntimeState(STATE_CONTEXT, context)
     }
 
-    private fun updateIconState(param: HookParam, fieldName: String, key: String) {
+    private fun updateIconState(cellularIcon: Any, fieldName: String, key: String) {
         val opt = PrefsBridge.getStringAsInt(key, 0)
         if (opt != 0) {
-            param.thisObject.setObjectField(fieldName, newReadonlyStateFlow(opt == 1))
+            cellularIcon.setObjectField(fieldName, newReadonlyStateFlow(opt == 1))
         }
     }
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobilePublicHookV.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobilePublicHookV.kt
@@ -61,14 +61,13 @@ class MobilePublicHookV : BaseHook() {
         const val STATE_CONTEXT = "MobilePublicHookV.context"
         const val STATE_SUB_IDS = "MobilePublicHookV.subIds"
         const val STATE_FLOW_PREFIX = "MobilePublicHookV.flow."
+        const val FIELD_IS_VISIBLE = "isVisible"
     }
 
     private val visibilityFlows = ConcurrentHashMap<Int, Any>()
 
-    /**
-     * MiuiCellularIconVM instances (by identityHashCode) already handled on the bind
-     * path, so the flows are not replaced again for every location.
-     */
+    // MiuiCellularIconVM instances (by identityHashCode) already handled on the bind
+    // path, so the flows are not replaced again for every location.
     private val appliedViewModels = ConcurrentHashMap.newKeySet<Int>()
 
     @Volatile
@@ -85,10 +84,7 @@ class MobilePublicHookV : BaseHook() {
         // constructor hook.
         if (miuiCellularIconVM.declaredConstructors.isNotEmpty()) {
             miuiCellularIconVM.hookAllConstructors {
-                after { param ->
-                    val mobileIconInteractor = param.args[2] ?: return@after
-                    applyToViewModel(param.thisObject, mobileIconInteractor)
-                }
+                after { param -> applyToViewModel(param.thisObject, param.args[2]) }
             }
             return
         }
@@ -104,52 +100,53 @@ class MobilePublicHookV : BaseHook() {
         // before-hook runs prior to the official bind collecting these flows, so the
         // replacement happens at the same point in time as the constructor hook did.
         miuiMobileIconBinder.findMethod { name("bind") }
-            .createBeforeHook { param ->
-                val cellularIcon = param.args[2] ?: return@createBeforeHook
-                // bind is called once per location (status bar / keyguard / control
-                // center) for the same VM, so only the first call is handled. Register
-                // the VM only after it succeeded, otherwise a single failure would make
-                // this VM be skipped forever.
-                val viewModelKey = System.identityHashCode(cellularIcon)
-                if (viewModelKey in appliedViewModels) return@createBeforeHook
-                val mobileIconInteractor = runCatching {
-                    cellularIcon.callMethodAs<Any>("getOriginIconInteractor")
-                }.getOrNull() ?: return@createBeforeHook
-                applyToViewModel(cellularIcon, mobileIconInteractor)
-                appliedViewModels.add(viewModelKey)
-            }
+            .createBeforeHook { param -> applyOnBind(param.args[2]) }
     }
 
-    /**
-     * Resolves the subId.
-     *
-     * On the old constructor-hook path args[2] is the MIUI-side interactor, which has a
-     * plain subId field. On HyperOS 3.3 (Android 17) the object reached through bind is a
-     * MobileIconInteractorImpl, where the field was renamed to subscriptionId (with a
-     * matching getSubscriptionId()), so reading subId throws MemberNotFoundException.
-     * The old name is tried first so behaviour on older versions is unchanged.
-     */
+    // bind is called once per location (status bar / keyguard / control center) for the
+    // same VM, so only the first call is handled. The VM is registered only after it
+    // succeeded, otherwise a single failure would make this VM be skipped forever.
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.READ_PHONE_STATE])
+    private fun applyOnBind(boundViewModel: Any?) {
+        val cellularIcon = boundViewModel ?: return
+        val viewModelKey = System.identityHashCode(cellularIcon)
+        if (viewModelKey in appliedViewModels) return
+        val mobileIconInteractor = runCatching {
+            cellularIcon.callMethodAs<Any>("getOriginIconInteractor")
+        }.getOrNull() ?: return
+        applyToViewModel(cellularIcon, mobileIconInteractor)
+        appliedViewModels.add(viewModelKey)
+    }
+
+    // Resolves the subId.
+    //
+    // On the old constructor-hook path args[2] is the MIUI-side interactor, which has a
+    // plain subId field. On HyperOS 3.3 (Android 17) the object reached through bind is a
+    // MobileIconInteractorImpl, where the field was renamed to subscriptionId (with a
+    // matching getSubscriptionId()), so reading subId throws MemberNotFoundException.
+    // The old name is tried first so behaviour on older versions is unchanged.
     private fun resolveSubId(interactor: Any): Int? =
         runCatching { interactor.getObjectFieldAs<Int>("subId") }.getOrNull()
             ?: runCatching { interactor.getObjectFieldAs<Int>("subscriptionId") }.getOrNull()
             ?: runCatching { interactor.callMethodAs<Int>("getSubscriptionId") }.getOrNull()
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.READ_PHONE_STATE])
-    private fun applyToViewModel(cellularIcon: Any, mobileIconInteractor: Any) {
-        val subId = resolveSubId(mobileIconInteractor) ?: return
+    private fun applyToViewModel(cellularIcon: Any, mobileIconInteractor: Any?) {
+        val interactor = mobileIconInteractor ?: return
+        val subId = resolveSubId(interactor) ?: return
         val isVisible = createVisibilityFlow()
 
         when {
             // 信号显示逻辑
             signalShowMode >= 1 -> {
-                cellularIcon.setObjectField("isVisible", isVisible)
+                cellularIcon.setObjectField(FIELD_IS_VISIBLE, isVisible)
                 trackVisibilityFlow(subId, isVisible)
                 refreshVisibility(subId, isVisible)
                 registerReceiver(EzXposed.appContext)
             }
             // 双排信号（signalShowMode == 0 且未隐藏卡）
             isEnableDouble && !(card1 || card2) -> {
-                cellularIcon.setObjectField("isVisible", isVisible)
+                cellularIcon.setObjectField(FIELD_IS_VISIBLE, isVisible)
                 trackVisibilityFlow(subId, isVisible)
                 val slotIndex = SubscriptionManager.getSlotIndex(subId)
                 val shouldShow = !MobileViewHelper.isAirplaneModeOn() &&
@@ -161,7 +158,7 @@ class MobilePublicHookV : BaseHook() {
             else -> {
                 val slotIndex = SubscriptionManager.getSlotIndex(subId)
                 if ((card1 && slotIndex == 0) || (card2 && slotIndex == 1)) {
-                    cellularIcon.setObjectField("isVisible", isVisible)
+                    cellularIcon.setObjectField(FIELD_IS_VISIBLE, isVisible)
                 }
             }
         }
@@ -210,9 +207,9 @@ class MobilePublicHookV : BaseHook() {
             ?.split(',')
             ?.mapNotNull { it.toIntOrNull() }
             .orEmpty()
-        savedIds.forEach { subId ->
+        for (subId in savedIds) {
             val flow = BaseHook.getHotReloadRuntimeState("$STATE_FLOW_PREFIX$subId", Any::class.java)
-                ?: return@forEach
+                ?: continue
             if (flow.javaClass.classLoader !== javaClass.classLoader) {
                 visibilityFlows[subId] = flow
             }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobileTypeSingle2Hook.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobileTypeSingle2Hook.kt
@@ -81,6 +81,7 @@ import io.github.lingqiqi5211.ezhooktool.core.loadClass
 import io.github.lingqiqi5211.ezhooktool.core.java.Constructors
 import io.github.lingqiqi5211.ezhooktool.xposed.EzXposed
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createAfterHook
+import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createBeforeHook
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createInterceptHook
 import io.github.lingqiqi5211.ezhooktool.xposed.dsl.createHook
 import java.util.concurrent.ConcurrentHashMap
@@ -113,6 +114,12 @@ object MobileTypeSingle2Hook : BaseHook() {
 
     @Volatile
     private var isWifiDefaultConnection: Boolean? = null
+
+    /**
+     * VMs (by identityHashCode) already handled on the bind path, so the flows are not
+     * replaced again for every location.
+     */
+    private val appliedViewModels = ConcurrentHashMap.newKeySet<Int>()
 
     private val boundViews = ConcurrentHashMap<Int, MutableSet<ViewGroup>>()
     private val renderStateStore = MobileTypeRenderStateStore()
@@ -155,72 +162,128 @@ object MobileTypeSingle2Hook : BaseHook() {
             }
         }
 
-        Constructors.find(miuiCellularIconVM).first().createAfterHook { param ->
-            val viewModel = param.thisObject
-            val interactor = param.args[1]
-            val miuiInteractor = param.args[2]
-
-            viewModel.setAdditionalInstanceField("interactor", interactor)
-            viewModel.setObjectField("wifiAvailable", miuiInteractor?.getObjectField("wifiAvailable"))
-
-            val subId = runCatching {
-                miuiInteractor?.getObjectFieldAs<Int>("subId")
-            }.getOrNull() ?: runCatching {
-                interactor?.getObjectFieldAs<Int>("subId")
-            }.getOrNull() ?: runCatching {
-                viewModel.getObjectFieldAs<Int>("subId")
-            }.getOrNull() ?: return@createAfterHook
-
-            val slotIndex = SubscriptionManager.getSlotIndex(subId)
-            if (isEnableDouble) {
-                viewModel.getObjectField("showName")?.let { originalFlow ->
-                    showNameFlowProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                    if (slotIndex == 0) {
-                        viewModel.setObjectField("showName", showNameFlowProxy.proxy!!)
-                    }
-                }
-                if (!hideIndicator) {
-                    viewModel.getObjectField("inOutVisible")?.let { originalFlow ->
-                        inOutVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                        if (slotIndex == 0) {
-                            viewModel.setObjectField("inOutVisible", inOutVisibleProxy.proxy!!)
-                        }
-                    }
-                    viewModel.getObjectField("inOutResId")?.let { originalFlow ->
-                        inOutResIdProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                        if (slotIndex == 0) {
-                            viewModel.setObjectField("inOutResId", inOutResIdProxy.proxy!!)
-                        }
-                    }
-                }
-                viewModel.getObjectField("mobileTypeSingleVisible")?.let { originalFlow ->
-                    mobileTypeSingleVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                    if (slotIndex == 0) {
-                        viewModel.setObjectField("mobileTypeSingleVisible", mobileTypeSingleVisibleProxy.proxy!!)
-                    }
-                }
-                viewModel.getObjectField("mobileTypeVisible")?.let { originalFlow ->
-                    mobileTypeVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                    if (slotIndex == 0) {
-                        viewModel.setObjectField("mobileTypeVisible", mobileTypeVisibleProxy.proxy!!)
-                    }
-                }
+        // OS 2.x / OS 3.0: MiuiCellularIconVM still has an <init>, so keep the original
+        // constructor hook.
+        if (miuiCellularIconVM.declaredConstructors.isNotEmpty()) {
+            Constructors.find(miuiCellularIconVM).first().createAfterHook { param ->
+                applyToViewModel(param.thisObject, param.args[1], param.args[2])
             }
-
-            registerMobileStateCollectors(
-                viewModel,
-                interactor,
-                subId,
-                slotIndex
-            )
-
-            if (isEnableDouble) {
-                syncDataSimProxiesNow()
-                registerDataSimBroadcast()
-            }
-            scheduleRefreshBoundViews()
+        } else {
+            // HyperOS 3.3 (Android 17): R8 inlined MiuiCellularIconVM's constructor away,
+            // so Constructors.find(...).first() throws MemberNotFoundException and the
+            // whole hook is lost. Handle it before MiuiMobileIconBinder#bind instead,
+            // where args[2] is the VM. Both interactors that used to be constructor
+            // arguments are reachable from the VM itself on the new version:
+            //   args[1] interactor     -> originIconInteractor
+            //   args[2] miuiInteractor -> only used to read wifiAvailable, and the new VM
+            //                             already has that field, so null is passed here
+            //                             and the copy is simply skipped.
+            miuiMobileIconBinder.findMethod { name("bind") }
+                .createBeforeHook { param ->
+                    // bind receives a MiuiMobileIconVMImpl wrapper whose inOutVisible /
+                    // mobileTypeVisible are ChannelFlowTransformLatest (cold flows, no
+                    // getValue) and which has no wifiAvailable field. The original
+                    // constructor hook saw the inner MiuiCellularIconVM, where all of
+                    // these are ReadonlyStateFlow, so unwrap first.
+                    val viewModel = unwrapCellProviderViewModel(param.args[2])
+                        ?: return@createBeforeHook
+                    // bind is called once per location for the same VM; register it only
+                    // after success so a single failure does not skip it forever
+                    val viewModelKey = System.identityHashCode(viewModel)
+                    if (viewModelKey in appliedViewModels) return@createBeforeHook
+                    val interactor = runCatching {
+                        viewModel.callMethodAs<Any>("getOriginIconInteractor")
+                    }.getOrNull() ?: return@createBeforeHook
+                    applyToViewModel(viewModel, interactor, null)
+                    appliedViewModels.add(viewModelKey)
+                }
         }
 
+        hookMobileViewExtras()
+    }
+
+    /**
+     * Resolves the subId.
+     *
+     * Older versions read subId straight off the interactor passed as a constructor
+     * argument. On HyperOS 3.3 that field was renamed to subscriptionId on
+     * MobileIconInteractorImpl (with a matching getSubscriptionId()). The old name is
+     * tried first, so older versions keep hitting the same branch as before.
+     */
+    private fun resolveSubId(viewModel: Any, interactor: Any?, miuiInteractor: Any?): Int? {
+        val candidates = listOfNotNull(miuiInteractor, interactor, viewModel)
+        for (target in candidates) {
+            runCatching { target.getObjectFieldAs<Int>("subId") }.getOrNull()?.let { return it }
+        }
+        for (target in candidates) {
+            runCatching { target.getObjectFieldAs<Int>("subscriptionId") }.getOrNull()?.let { return it }
+            runCatching { target.callMethodAs<Int>("getSubscriptionId") }.getOrNull()?.let { return it }
+        }
+        return null
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun applyToViewModel(viewModel: Any, interactor: Any?, miuiInteractor: Any?) {
+        viewModel.setAdditionalInstanceField("interactor", interactor)
+        // The new VM already owns a wifiAvailable field, so there is nothing to copy when
+        // no miuiInteractor was supplied
+        if (miuiInteractor != null) {
+            viewModel.setObjectField("wifiAvailable", miuiInteractor.getObjectField("wifiAvailable"))
+        }
+
+        val subId = resolveSubId(viewModel, interactor, miuiInteractor) ?: return
+
+        val slotIndex = SubscriptionManager.getSlotIndex(subId)
+        if (isEnableDouble) {
+            viewModel.getObjectField("showName")?.let { originalFlow ->
+                showNameFlowProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
+                if (slotIndex == 0) {
+                    viewModel.setObjectField("showName", showNameFlowProxy.proxy!!)
+                }
+            }
+            if (!hideIndicator) {
+                viewModel.getObjectField("inOutVisible")?.let { originalFlow ->
+                    inOutVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
+                    if (slotIndex == 0) {
+                        viewModel.setObjectField("inOutVisible", inOutVisibleProxy.proxy!!)
+                    }
+                }
+                viewModel.getObjectField("inOutResId")?.let { originalFlow ->
+                    inOutResIdProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
+                    if (slotIndex == 0) {
+                        viewModel.setObjectField("inOutResId", inOutResIdProxy.proxy!!)
+                    }
+                }
+            }
+            viewModel.getObjectField("mobileTypeSingleVisible")?.let { originalFlow ->
+                mobileTypeSingleVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
+                if (slotIndex == 0) {
+                    viewModel.setObjectField("mobileTypeSingleVisible", mobileTypeSingleVisibleProxy.proxy!!)
+                }
+            }
+            viewModel.getObjectField("mobileTypeVisible")?.let { originalFlow ->
+                mobileTypeVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
+                if (slotIndex == 0) {
+                    viewModel.setObjectField("mobileTypeVisible", mobileTypeVisibleProxy.proxy!!)
+                }
+            }
+        }
+
+        registerMobileStateCollectors(
+            viewModel,
+            interactor,
+            subId,
+            slotIndex
+        )
+
+        if (isEnableDouble) {
+            syncDataSimProxiesNow()
+            registerDataSimBroadcast()
+        }
+        scheduleRefreshBoundViews()
+    }
+
+    private fun hookMobileViewExtras() {
         modernStatusBarMobileView.findAllMethods { name("constructAndBind") }
             .forEach { method ->
                 method.createInterceptHook { chain ->
@@ -250,9 +313,24 @@ object MobileTypeSingle2Hook : BaseHook() {
     }
 
     private fun showMobileTypeSingle() {
-        mOperatorConfig.constructors[0].createAfterHook {
-            it.thisObject.setObjectField("showMobileDataTypeSingle", true)
+        // OS 2.x / OS 3.0: OperatorConfig still has an <init>.
+        val constructors = mOperatorConfig.constructors
+        if (constructors.isNotEmpty()) {
+            constructors[0].createAfterHook {
+                it.thisObject.setObjectField("showMobileDataTypeSingle", true)
+            }
+            return
         }
+
+        // HyperOS 3.3 (Android 17): R8 inlined OperatorConfig's constructor into
+        // MiuiOperatorCustomizedPolicy#getMiuiOperatorConfig (see HideVoWiFiIcon), so
+        // constructors[0] throws ArrayIndexOutOfBoundsException. Hook that method's
+        // return value instead.
+        loadClass("com.android.systemui.MiuiOperatorCustomizedPolicy")
+            .findMethod { name("getMiuiOperatorConfig") }
+            .createAfterHook { param ->
+                param.result?.setObjectField("showMobileDataTypeSingle", true)
+            }
     }
 
     private fun unwrapCellProviderViewModel(viewModel: Any?): Any? {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobileTypeSingle2Hook.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemui/statusbar/mobile/MobileTypeSingle2Hook.kt
@@ -91,6 +91,22 @@ object MobileTypeSingle2Hook : BaseHook() {
     private const val LAST_BOUND_VIEW_MODEL_KEY = "mobile_type_single2_last_bound_vm"
     private const val DATA_SIM_CONTEXT_KEY = "MobileTypeSingle2Hook.dataSimContext"
 
+    private const val FIELD_SHOW_NAME = "showName"
+    private const val FIELD_IN_OUT_VISIBLE = "inOutVisible"
+    private const val FIELD_IN_OUT_RES_ID = "inOutResId"
+    private const val FIELD_MOBILE_TYPE_SINGLE_VISIBLE = "mobileTypeSingleVisible"
+    private const val FIELD_MOBILE_TYPE_VISIBLE = "mobileTypeVisible"
+    private const val FIELD_WIFI_AVAILABLE = "wifiAvailable"
+    private const val FIELD_SUB_ID = "subId"
+    private const val FIELD_IS_DATA_CONNECTED = "isDataConnected"
+    private const val FIELD_CONNECT_REPO = "connectRepo"
+    private const val FIELD_DEFAULT_CONNECTIONS = "defaultConnections"
+    private const val FIELD_MOBILE_ICONS_VIEW_MODEL = "mobileIconsViewModel"
+    private const val FIELD_WIFI = "wifi"
+    private const val FIELD_IS_DEFAULT = "isDefault"
+    private const val VIEW_MOBILE_TYPE_SINGLE = "mobile_type_single"
+    private const val VIEW_MOBILE_TYPE = "mobile_type"
+
     private val showNameFlowProxy = DataSimFlowProxy("")
     private val inOutVisibleProxy = DataSimFlowProxy(false)
     private val inOutResIdProxy = DataSimFlowProxy(0)
@@ -115,10 +131,8 @@ object MobileTypeSingle2Hook : BaseHook() {
     @Volatile
     private var isWifiDefaultConnection: Boolean? = null
 
-    /**
-     * VMs (by identityHashCode) already handled on the bind path, so the flows are not
-     * replaced again for every location.
-     */
+    // VMs (by identityHashCode) already handled on the bind path, so the flows are not
+    // replaced again for every location.
     private val appliedViewModels = ConcurrentHashMap.newKeySet<Int>()
 
     private val boundViews = ConcurrentHashMap<Int, MutableSet<ViewGroup>>()
@@ -179,41 +193,41 @@ object MobileTypeSingle2Hook : BaseHook() {
             //                             already has that field, so null is passed here
             //                             and the copy is simply skipped.
             miuiMobileIconBinder.findMethod { name("bind") }
-                .createBeforeHook { param ->
-                    // bind receives a MiuiMobileIconVMImpl wrapper whose inOutVisible /
-                    // mobileTypeVisible are ChannelFlowTransformLatest (cold flows, no
-                    // getValue) and which has no wifiAvailable field. The original
-                    // constructor hook saw the inner MiuiCellularIconVM, where all of
-                    // these are ReadonlyStateFlow, so unwrap first.
-                    val viewModel = unwrapCellProviderViewModel(param.args[2])
-                        ?: return@createBeforeHook
-                    // bind is called once per location for the same VM; register it only
-                    // after success so a single failure does not skip it forever
-                    val viewModelKey = System.identityHashCode(viewModel)
-                    if (viewModelKey in appliedViewModels) return@createBeforeHook
-                    val interactor = runCatching {
-                        viewModel.callMethodAs<Any>("getOriginIconInteractor")
-                    }.getOrNull() ?: return@createBeforeHook
-                    applyToViewModel(viewModel, interactor, null)
-                    appliedViewModels.add(viewModelKey)
-                }
+                .createBeforeHook { param -> applyOnBind(param.args[2]) }
         }
 
         hookMobileViewExtras()
     }
 
-    /**
-     * Resolves the subId.
-     *
-     * Older versions read subId straight off the interactor passed as a constructor
-     * argument. On HyperOS 3.3 that field was renamed to subscriptionId on
-     * MobileIconInteractorImpl (with a matching getSubscriptionId()). The old name is
-     * tried first, so older versions keep hitting the same branch as before.
-     */
+    // bind receives a MiuiMobileIconVMImpl wrapper whose inOutVisible / mobileTypeVisible
+    // are ChannelFlowTransformLatest (cold flows, no getValue) and which has no
+    // wifiAvailable field. The original constructor hook saw the inner MiuiCellularIconVM,
+    // where all of these are ReadonlyStateFlow, so unwrap first.
+    //
+    // bind is called once per location for the same VM; the VM is registered only after
+    // success so a single failure does not skip it forever.
+    @SuppressLint("MissingPermission")
+    private fun applyOnBind(boundViewModel: Any?) {
+        val viewModel = unwrapCellProviderViewModel(boundViewModel) ?: return
+        val viewModelKey = System.identityHashCode(viewModel)
+        if (viewModelKey in appliedViewModels) return
+        val interactor = runCatching {
+            viewModel.callMethodAs<Any>("getOriginIconInteractor")
+        }.getOrNull() ?: return
+        applyToViewModel(viewModel, interactor, null)
+        appliedViewModels.add(viewModelKey)
+    }
+
+    // Resolves the subId.
+    //
+    // Older versions read subId straight off the interactor passed as a constructor
+    // argument. On HyperOS 3.3 that field was renamed to subscriptionId on
+    // MobileIconInteractorImpl (with a matching getSubscriptionId()). The old name is
+    // tried first, so older versions keep hitting the same branch as before.
     private fun resolveSubId(viewModel: Any, interactor: Any?, miuiInteractor: Any?): Int? {
         val candidates = listOfNotNull(miuiInteractor, interactor, viewModel)
         for (target in candidates) {
-            runCatching { target.getObjectFieldAs<Int>("subId") }.getOrNull()?.let { return it }
+            runCatching { target.getObjectFieldAs<Int>(FIELD_SUB_ID) }.getOrNull()?.let { return it }
         }
         for (target in candidates) {
             runCatching { target.getObjectFieldAs<Int>("subscriptionId") }.getOrNull()?.let { return it }
@@ -228,45 +242,22 @@ object MobileTypeSingle2Hook : BaseHook() {
         // The new VM already owns a wifiAvailable field, so there is nothing to copy when
         // no miuiInteractor was supplied
         if (miuiInteractor != null) {
-            viewModel.setObjectField("wifiAvailable", miuiInteractor.getObjectField("wifiAvailable"))
+            viewModel.setObjectField(FIELD_WIFI_AVAILABLE, miuiInteractor.getObjectField(FIELD_WIFI_AVAILABLE))
         }
 
         val subId = resolveSubId(viewModel, interactor, miuiInteractor) ?: return
 
         val slotIndex = SubscriptionManager.getSlotIndex(subId)
         if (isEnableDouble) {
-            viewModel.getObjectField("showName")?.let { originalFlow ->
-                showNameFlowProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                if (slotIndex == 0) {
-                    viewModel.setObjectField("showName", showNameFlowProxy.proxy!!)
-                }
-            }
+            installDataSimProxy(viewModel, FIELD_SHOW_NAME, showNameFlowProxy, subId, slotIndex)
             if (!hideIndicator) {
-                viewModel.getObjectField("inOutVisible")?.let { originalFlow ->
-                    inOutVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                    if (slotIndex == 0) {
-                        viewModel.setObjectField("inOutVisible", inOutVisibleProxy.proxy!!)
-                    }
-                }
-                viewModel.getObjectField("inOutResId")?.let { originalFlow ->
-                    inOutResIdProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                    if (slotIndex == 0) {
-                        viewModel.setObjectField("inOutResId", inOutResIdProxy.proxy!!)
-                    }
-                }
+                installDataSimProxy(viewModel, FIELD_IN_OUT_VISIBLE, inOutVisibleProxy, subId, slotIndex)
+                installDataSimProxy(viewModel, FIELD_IN_OUT_RES_ID, inOutResIdProxy, subId, slotIndex)
             }
-            viewModel.getObjectField("mobileTypeSingleVisible")?.let { originalFlow ->
-                mobileTypeSingleVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                if (slotIndex == 0) {
-                    viewModel.setObjectField("mobileTypeSingleVisible", mobileTypeSingleVisibleProxy.proxy!!)
-                }
-            }
-            viewModel.getObjectField("mobileTypeVisible")?.let { originalFlow ->
-                mobileTypeVisibleProxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
-                if (slotIndex == 0) {
-                    viewModel.setObjectField("mobileTypeVisible", mobileTypeVisibleProxy.proxy!!)
-                }
-            }
+            installDataSimProxy(
+                viewModel, FIELD_MOBILE_TYPE_SINGLE_VISIBLE, mobileTypeSingleVisibleProxy, subId, slotIndex
+            )
+            installDataSimProxy(viewModel, FIELD_MOBILE_TYPE_VISIBLE, mobileTypeVisibleProxy, subId, slotIndex)
         }
 
         registerMobileStateCollectors(
@@ -283,14 +274,28 @@ object MobileTypeSingle2Hook : BaseHook() {
         scheduleRefreshBoundViews()
     }
 
+    // Only slot 0 owns the shared data-SIM proxy; every other slot just registers its
+    // original flow with the proxy so the broadcast can switch over to it later.
+    private fun installDataSimProxy(
+        viewModel: Any,
+        fieldName: String,
+        proxy: DataSimFlowProxy,
+        subId: Int,
+        slotIndex: Int
+    ) {
+        val originalFlow = viewModel.getObjectField(fieldName) ?: return
+        proxy.setupForSlot(slotIndex, subId, originalFlow, MobileViewHelper::isSingleSimMode)
+        if (slotIndex == 0) {
+            viewModel.setObjectField(fieldName, proxy.proxy!!)
+        }
+    }
+
     private fun hookMobileViewExtras() {
         modernStatusBarMobileView.findAllMethods { name("constructAndBind") }
             .forEach { method ->
                 method.createInterceptHook { chain ->
                     val result = chain.proceed()
-                    val rootView = result as? ViewGroup ?: return@createInterceptHook result
-                    val viewModel = resolveConstructAndBindViewModel(chain.args.toList()) ?: return@createInterceptHook result
-                    bindConstructedMobileViewIfNeeded(rootView, viewModel)
+                    bindConstructedResult(result, chain.args.toList())
                     result
                 }
             }
@@ -342,18 +347,27 @@ object MobileTypeSingle2Hook : BaseHook() {
         }
     }
 
+    @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
+    private fun bindConstructedResult(result: Any?, args: List<Any?>) {
+        val rootView = result as? ViewGroup ?: return
+        val viewModel = resolveConstructAndBindViewModel(args) ?: return
+        bindConstructedMobileViewIfNeeded(rootView, viewModel)
+    }
+
     private fun resolveConstructAndBindViewModel(args: List<Any?>): Any? {
-        args.asReversed().forEach { arg ->
-            val candidate = unwrapCellProviderViewModel(arg) ?: return@forEach
+        for (arg in args.asReversed()) {
+            val candidate = unwrapCellProviderViewModel(arg) ?: continue
             val simpleName = candidate.javaClass.simpleName
             if (simpleName.contains("MobileIconVM", ignoreCase = true) ||
                 simpleName.contains("CellularIcon", ignoreCase = true)
             ) {
                 return candidate
             }
-            val hasShowName = runCatching { candidate.getObjectField("showName") != null }.getOrDefault(false)
-            val hasLargeVisible = runCatching { candidate.getObjectField("mobileTypeSingleVisible") != null }.getOrDefault(false)
-            val hasSmallVisible = runCatching { candidate.getObjectField("mobileTypeVisible") != null }.getOrDefault(false)
+            val hasShowName = runCatching { candidate.getObjectField(FIELD_SHOW_NAME) != null }.getOrDefault(false)
+            val hasLargeVisible =
+                runCatching { candidate.getObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE) != null }.getOrDefault(false)
+            val hasSmallVisible =
+                runCatching { candidate.getObjectField(FIELD_MOBILE_TYPE_VISIBLE) != null }.getOrDefault(false)
             if (hasShowName && (hasLargeVisible || hasSmallVisible)) {
                 return candidate
             }
@@ -387,7 +401,7 @@ object MobileTypeSingle2Hook : BaseHook() {
     @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
     private fun bindConstructedMobileView(rootView: ViewGroup, viewModel: Any) {
         val interactor = viewModel.getAdditionalInstanceFieldAs<Any>("interactor")
-        val subId = rootView.getIntField("subId")
+        val subId = rootView.getIntField(FIELD_SUB_ID)
         val slotIndex = SubscriptionManager.getSlotIndex(subId)
         if (slotIndex == -1) return
         cacheBoundView(subId, rootView)
@@ -397,8 +411,8 @@ object MobileTypeSingle2Hook : BaseHook() {
 
         // 大 5G 样式：移除小 5G ImageView，配置大 5G TextView
         if (showMobileType) {
-            containerLeft.findViewByIdName("mobile_type")?.let { containerLeft.removeView(it) }
-            val textView = mobileGroup.findViewByIdName("mobile_type_single") as TextView
+            containerLeft.findViewByIdName(VIEW_MOBILE_TYPE)?.let { containerLeft.removeView(it) }
+            val textView = mobileGroup.findViewByIdName(VIEW_MOBILE_TYPE_SINGLE) as TextView
             if (!getLocation) {
                 mobileGroup.removeView(textView)
                 mobileGroup.addView(textView)
@@ -425,11 +439,11 @@ object MobileTypeSingle2Hook : BaseHook() {
 
             when (mobileNetworkType) {
                 0, 2 -> {
-                    viewModel.setObjectField("mobileTypeSingleVisible", newReadonlyStateFlow(false))
+                    viewModel.setObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE, newReadonlyStateFlow(false))
 
                     val defaultConnections = runCatching {
-                        interactor?.getObjectFieldAs<Any>("connectRepo")
-                            ?.getObjectFieldAs<Any>("defaultConnections")
+                        interactor?.getObjectFieldAs<Any>(FIELD_CONNECT_REPO)
+                            ?.getObjectFieldAs<Any>(FIELD_DEFAULT_CONNECTIONS)
                     }.getOrNull()
 
                     if (defaultConnections != null) {
@@ -441,13 +455,13 @@ object MobileTypeSingle2Hook : BaseHook() {
                     } else {
                         bindMobileTypeSingleVisibilityWithWifiFlow(
                             viewModel = viewModel,
-                            wifiFlow = viewModel.getObjectFieldAs("wifiAvailable"),
+                            wifiFlow = viewModel.getObjectFieldAs(FIELD_WIFI_AVAILABLE),
                             subId = subId
                         )
                     }
                 }
-                1 -> viewModel.setObjectField("mobileTypeSingleVisible", newReadonlyStateFlow(true))
-                3 -> viewModel.setObjectField("mobileTypeSingleVisible", newReadonlyStateFlow(false))
+                1 -> viewModel.setObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE, newReadonlyStateFlow(true))
+                3 -> viewModel.setObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE, newReadonlyStateFlow(false))
                 else -> Unit
             }
             applyBoundViewState(rootView)
@@ -462,28 +476,28 @@ object MobileTypeSingle2Hook : BaseHook() {
 
         when (mobileNetworkType) {
             2 -> {
-                val wifiFlow = viewModel.getObjectFieldAs<Any>("wifiAvailable")
+                val wifiFlow = viewModel.getObjectFieldAs<Any>(FIELD_WIFI_AVAILABLE)
                 val initWifiOn = runCatching { getStateFlowValue(wifiFlow) as Boolean }
                     .getOrElse { safeIsWifiConnected() ?: false }
                 val flow = newReadonlyStateFlow(!initWifiOn)
-                viewModel.setObjectField("mobileTypeVisible", flow)
+                viewModel.setObjectField(FIELD_MOBILE_TYPE_VISIBLE, flow)
                 MiuiStub.javaAdapter.alwaysCollectFlow(
                     wifiFlow,
                     Consumer<Boolean> { wifiOn -> setStateFlowValue(flow, !wifiOn) }
                 )
             }
-            1 -> viewModel.setObjectField("mobileTypeVisible", newReadonlyStateFlow(true))
-            3 -> viewModel.setObjectField("mobileTypeVisible", newReadonlyStateFlow(false))
+            1 -> viewModel.setObjectField(FIELD_MOBILE_TYPE_VISIBLE, newReadonlyStateFlow(true))
+            3 -> viewModel.setObjectField(FIELD_MOBILE_TYPE_VISIBLE, newReadonlyStateFlow(false))
             4 -> {
-                val wifiFlow = viewModel.getObjectFieldAs<Any>("wifiAvailable")
-                val dataConnectedFlow = interactor?.getObjectFieldAs<Any>("isDataConnected")
+                val wifiFlow = viewModel.getObjectFieldAs<Any>(FIELD_WIFI_AVAILABLE)
+                val dataConnectedFlow = interactor?.getObjectFieldAs<Any>(FIELD_IS_DATA_CONNECTED)
 
                 // 先读当前值
                 val initWifiOn = runCatching { getStateFlowValue(wifiFlow) as Boolean }.getOrDefault(false)
                 val initDataConnected = runCatching { getStateFlowValue(dataConnectedFlow) as Boolean }.getOrDefault(false)
 
                 val flow = newReadonlyStateFlow(!initWifiOn && initDataConnected)
-                viewModel.setObjectField("mobileTypeVisible", flow)
+                viewModel.setObjectField(FIELD_MOBILE_TYPE_VISIBLE, flow)
 
                 var wifiOn = initWifiOn
                 var dataConnected = initDataConnected
@@ -513,7 +527,7 @@ object MobileTypeSingle2Hook : BaseHook() {
     }
 
     private fun bindMobileTypeSingleVisibilityWithWifiFlow(viewModel: Any, wifiFlow: Any, subId: Int) {
-        val visibleFlow = viewModel.getObjectField("mobileTypeSingleVisible")
+        val visibleFlow = viewModel.getObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE)
         val wifiFromFlow = runCatching { getStateFlowValue(wifiFlow) as Boolean }.getOrNull()
         val wifiConnectedNow = safeIsWifiConnected() ?: wifiFromFlow ?: false
         val initialVisible = !wifiConnectedNow
@@ -530,11 +544,11 @@ object MobileTypeSingle2Hook : BaseHook() {
     }
 
     private fun bindMobileTypeSingleVisibilityWithDefaultConnections(viewModel: Any, defaultConnections: Any, subId: Int) {
-        val visibleFlow = viewModel.getObjectField("mobileTypeSingleVisible")
+        val visibleFlow = viewModel.getObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE)
         val initialIsWifiDefault = runCatching {
             getStateFlowValue(defaultConnections)
-                ?.getObjectField("wifi")
-                ?.getBooleanField("isDefault")
+                ?.getObjectField(FIELD_WIFI)
+                ?.getBooleanField(FIELD_IS_DEFAULT)
         }.getOrNull() ?: (safeIsWifiConnected() ?: false)
         val initialVisible = !initialIsWifiDefault
         setStateFlowValue(visibleFlow, initialVisible)
@@ -543,7 +557,7 @@ object MobileTypeSingle2Hook : BaseHook() {
             defaultConnections,
             Consumer<Any> { conn ->
                 val isWifiDefault = runCatching {
-                    conn.getObjectField("wifi")?.getBooleanField("isDefault")
+                    conn.getObjectField(FIELD_WIFI)?.getBooleanField(FIELD_IS_DEFAULT)
                 }.getOrNull() ?: (safeIsWifiConnected() ?: false)
                 val visible = !isWifiDefault
                 setStateFlowValue(visibleFlow, visible)
@@ -555,12 +569,12 @@ object MobileTypeSingle2Hook : BaseHook() {
     private fun syncWifiDefaultConnectionSnapshot(interactor: Any?) {
         val wifiConnectedNow = safeIsWifiConnected()
         val currentIsWifiDefault = runCatching {
-            interactor?.getObjectFieldAs<Any>("connectRepo")
-                ?.getObjectFieldAs<Any>("defaultConnections")
+            interactor?.getObjectFieldAs<Any>(FIELD_CONNECT_REPO)
+                ?.getObjectFieldAs<Any>(FIELD_DEFAULT_CONNECTIONS)
                 ?.let { defaultConnections ->
                     getStateFlowValue(defaultConnections)
-                        ?.getObjectField("wifi")
-                        ?.getBooleanField("isDefault")
+                        ?.getObjectField(FIELD_WIFI)
+                        ?.getBooleanField(FIELD_IS_DEFAULT)
                 }
         }.getOrNull()
         isWifiDefaultConnection = normalizeWifiDefaultConnection(currentIsWifiDefault, wifiConnectedNow)
@@ -599,23 +613,23 @@ object MobileTypeSingle2Hook : BaseHook() {
     @SuppressLint("NewApi")
     private fun setOnDefaultConnectionsListener(mobileUiAdapter: Any) {
         val miuiInt = runCatching {
-            mobileUiAdapter.getObjectFieldAs<Any>("mobileIconsViewModel")
+            mobileUiAdapter.getObjectFieldAs<Any>(FIELD_MOBILE_ICONS_VIEW_MODEL)
                 .getObjectFieldAs<Any>("miuiIntsLazy")
                 .callMethodOrNull("get")
         }.recoverCatching {
-            mobileUiAdapter.getObjectFieldAs<Any>("mobileIconsViewModel")
+            mobileUiAdapter.getObjectFieldAs<Any>(FIELD_MOBILE_ICONS_VIEW_MODEL)
                 .getObjectFieldAs<Any>("miuiInt")
         }.getOrNull() ?: return
 
-        val defaultConnections = miuiInt.getObjectFieldAs<Any>("connectRepo")
-            .getObjectFieldAs<Any>("defaultConnections")
+        val defaultConnections = miuiInt.getObjectFieldAs<Any>(FIELD_CONNECT_REPO)
+            .getObjectFieldAs<Any>(FIELD_DEFAULT_CONNECTIONS)
 
         if (defaultConnectionsCollectorSource !== miuiInt) {
             defaultConnectionsCollectorJob?.cancel()
             val initialRawIsWifiDefault = runCatching {
                 getStateFlowValue(defaultConnections)
-                    ?.getObjectField("wifi")
-                    ?.getBooleanField("isDefault")
+                    ?.getObjectField(FIELD_WIFI)
+                    ?.getBooleanField(FIELD_IS_DEFAULT)
             }.getOrNull()
             isWifiDefaultConnection = normalizeWifiDefaultConnection(initialRawIsWifiDefault, safeIsWifiConnected())
             scheduleRefreshBoundViews()
@@ -623,7 +637,7 @@ object MobileTypeSingle2Hook : BaseHook() {
                 defaultConnections,
                 Consumer<Any> { conn ->
                     val rawIsWifiDefault = runCatching {
-                        conn.getObjectField("wifi")?.getBooleanField("isDefault")
+                        conn.getObjectField(FIELD_WIFI)?.getBooleanField(FIELD_IS_DEFAULT)
                     }.getOrNull()
                     isWifiDefaultConnection = normalizeWifiDefaultConnection(rawIsWifiDefault, safeIsWifiConnected())
                     scheduleRefreshBoundViews()
@@ -636,11 +650,11 @@ object MobileTypeSingle2Hook : BaseHook() {
     @SuppressLint("NewApi")
     private fun setOnDataChangedListener(mobileUiAdapter: Any) {
         val miuiInt = runCatching {
-            mobileUiAdapter.getObjectFieldAs<Any>("mobileIconsViewModel")
+            mobileUiAdapter.getObjectFieldAs<Any>(FIELD_MOBILE_ICONS_VIEW_MODEL)
                 .getObjectFieldAs<Any>("miuiIntsLazy")
                 .callMethodOrNull("get")
         }.recoverCatching {
-            mobileUiAdapter.getObjectFieldAs<Any>("mobileIconsViewModel")
+            mobileUiAdapter.getObjectFieldAs<Any>(FIELD_MOBILE_ICONS_VIEW_MODEL)
                 .getObjectFieldAs<Any>("miuiInt")
         }.getOrNull() ?: return
 
@@ -660,32 +674,32 @@ object MobileTypeSingle2Hook : BaseHook() {
         renderStateStore.onCollectorAttached(subId, slotIndex)
 
         collectRenderState(
-            viewModel.getObjectField("showName")
+            viewModel.getObjectField(FIELD_SHOW_NAME)
         ) { value ->
             renderStateStore.updateShowName(subId, value as? String ?: "")
         }
         collectRenderState(
-            viewModel.getObjectField("inOutVisible")
+            viewModel.getObjectField(FIELD_IN_OUT_VISIBLE)
         ) { value ->
             coerceBooleanState(value)?.let { renderStateStore.updateInOutVisible(subId, it) }
         }
         collectRenderState(
-            interactor?.getObjectField("isDataConnected")
+            interactor?.getObjectField(FIELD_IS_DATA_CONNECTED)
         ) { value ->
             coerceBooleanState(value)?.let { renderStateStore.updateDataConnected(subId, it) }
         }
         collectRenderState(
-            viewModel.getObjectField("wifiAvailable")
+            viewModel.getObjectField(FIELD_WIFI_AVAILABLE)
         ) { value ->
             coerceBooleanState(value)?.let { renderStateStore.updateWifiAvailable(subId, it) }
         }
         collectRenderState(
-            viewModel.getObjectField("mobileTypeSingleVisible")
+            viewModel.getObjectField(FIELD_MOBILE_TYPE_SINGLE_VISIBLE)
         ) { value ->
             coerceBooleanState(value)?.let { renderStateStore.updateMobileTypeSingleVisible(subId, it) }
         }
         collectRenderState(
-            viewModel.getObjectField("mobileTypeVisible")
+            viewModel.getObjectField(FIELD_MOBILE_TYPE_VISIBLE)
         ) { value ->
             coerceBooleanState(value)?.let { renderStateStore.updateMobileTypeVisible(subId, it) }
         }
@@ -746,7 +760,7 @@ object MobileTypeSingle2Hook : BaseHook() {
 
     @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
     private fun applyBoundViewState(rootView: ViewGroup) {
-        val viewSubId = runCatching { rootView.getIntField("subId") }.getOrDefault(-1)
+        val viewSubId = runCatching { rootView.getIntField(FIELD_SUB_ID) }.getOrDefault(-1)
         if (viewSubId == -1) return
 
         val targetSubId = renderStateStore.resolveRenderSubId(
@@ -756,8 +770,8 @@ object MobileTypeSingle2Hook : BaseHook() {
         )
         val renderState = renderStateStore.snapshot(targetSubId)
 
-        val mobileTypeSingleView = rootView.findViewByIdName("mobile_type_single") as? TextView
-        val mobileTypeSmallView = rootView.findViewByIdName("mobile_type") as? ImageView
+        val mobileTypeSingleView = rootView.findViewByIdName(VIEW_MOBILE_TYPE_SINGLE) as? TextView
+        val mobileTypeSmallView = rootView.findViewByIdName(VIEW_MOBILE_TYPE) as? ImageView
         val inOutView = rootView.findViewByIdName("mobile_left_mobile_inout") as? ImageView
 
         val wifiConnectedNow = safeIsWifiConnected()

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/thememanager/AllowThirdTheme.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/thememanager/AllowThirdTheme.java
@@ -45,7 +45,11 @@ public class AllowThirdTheme extends BaseHook {
 
     @Override
     protected boolean initDexKit() {
-        mCheckRightsIsLegalMethod = requiredMember("CheckRightsIsLegal", new IDexKit() {
+        // The anchor strings "ThemeManagerTag" / "check rights isLegal: " no longer exist
+        // in the HyperOS 3.3 theme store, so DexKit cannot locate the target method.
+        // Use optionalMember: skip when it is not found instead of throwing and leaving
+        // "Skip hook because initDexKit failed" behind.
+        mCheckRightsIsLegalMethod = optionalMember("CheckRightsIsLegal", new IDexKit() {
             @Override
             public BaseData dexkit(DexKitBridge bridge) throws ReflectiveOperationException {
                 MethodData methodData = bridge.findMethod(FindMethod.create()
@@ -62,6 +66,9 @@ public class AllowThirdTheme extends BaseHook {
     public void init() {
         runOnApplicationAttach(RearScreenFlowGuard::ensureActivityTrackerRegistered);
 
+        if (mCheckRightsIsLegalMethod == null) {
+            return;
+        }
         hookMethod(mCheckRightsIsLegalMethod, new IMethodHook() {
             @Override
             public void before(HookParam param) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/thememanager/DisableThemeAdNew.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/thememanager/DisableThemeAdNew.kt
@@ -46,17 +46,41 @@ class DisableThemeAdNew : BaseHook() {
         }.onFailure {
             XposedLog.e(TAG, it)
         }
-        runCatching {
-            loadClass("com.android.thememanager.basemodule.ad.model.AdInfoResponse").findMethod { name("isAdValid"); paramCount(1) }
-                .createHook {
-                    returnConstant(false)
-                }
-        }.onFailure {
-            XposedLog.e(TAG, it)
+        // AdInfoResponse no longer exists in the global theme store on HyperOS 3.3 (the
+        // built-in ad model was replaced wholesale by third-party SDKs). A missing class
+        // is expected here and should not be logged as an error with a full stack trace.
+        val adInfoResponse = findClassIfExists("com.android.thememanager.basemodule.ad.model.AdInfoResponse")
+        if (adInfoResponse == null) {
+            XposedLog.d(TAG, packageName, "AdInfoResponse not present, skip")
+        } else {
+            runCatching {
+                adInfoResponse.findMethod { name("isAdValid"); paramCount(1) }
+                    .createHook {
+                        returnConstant(false)
+                    }
+            }.onFailure {
+                XposedLog.e(TAG, it)
+            }
         }
 
-        removeAds(loadClass("com.android.thememanager.recommend.view.listview.viewholder.SelfFontItemAdViewHolder"))
-        removeAds(loadClass("com.android.thememanager.recommend.view.listview.viewholder.SelfRingtoneItemAdViewHolder"))
+        // These two built-in ad ViewHolders (like AdInfoResponse above) are gone on some
+        // versions -- the global theme store on HyperOS 3.3 uses third-party ad SDKs and
+        // no longer ships com.android.thememanager.basemodule.ad or
+        // Self*ItemAdViewHolder.
+        // The loadClass calls here had no fallback, so they threw ClassNotFoundError and
+        // aborted init(), discarding everything after the DrmManager hooks that had
+        // already succeeded.
+        removeAdsIfPresent("com.android.thememanager.recommend.view.listview.viewholder.SelfFontItemAdViewHolder")
+        removeAdsIfPresent("com.android.thememanager.recommend.view.listview.viewholder.SelfRingtoneItemAdViewHolder")
+    }
+
+    private fun removeAdsIfPresent(className: String) {
+        val clazz = findClassIfExists(className)
+        if (clazz == null) {
+            XposedLog.d(TAG, packageName, "$className not present, skip")
+            return
+        }
+        removeAds(clazz)
     }
 
     private fun removeAds(clazz: Class<*>) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/DeviceHelper.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/DeviceHelper.kt
@@ -258,7 +258,7 @@ object DeviceHelper {
                 VersionInfo(36, 3.0f, 3.3f, SUPPORT_FULL),
 
                 // 部分功能未适配
-                // VersionInfo(37, 3.0f, 3.3f, SUPPORT_PARTIAL),
+                VersionInfo(37, 3.0f, 3.3f, SUPPORT_PARTIAL),
 
                 // 未适配
                 VersionInfo(36, 2.0f, 2.2f, SUPPORT_NOT)

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/PluginFactory.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/PluginFactory.kt
@@ -31,7 +31,24 @@ internal class PluginFactory(obj: Any) {
     }
 
     lateinit var pluginCtxRef: WeakReference<Context>
-    val mComponentName: Any? = com.sevtinge.hyperceiler.libhook.base.BaseHook.getObjectField(obj , "mComponentName")
+
+    /**
+     * The field in PluginInstance$PluginFactory that holds the plugin's component name.
+     *
+     * It is called mComponentName on OS 2.x / OS 3.0. HyperOS 3.3 (Android 17) followed
+     * AOSP in dropping the m prefix and renamed it to componentName, so reading only the
+     * old name throws MemberNotFoundException -- which the caller's runCatching swallows
+     * into a bare "Failed to create plugin context.". The result is that every
+     * miui.systemui.plugin feature (volume/brightness percentage, QS colors, control
+     * center media card, ...) silently stops working. The old name is tried first so
+     * behaviour on older versions is unchanged.
+     */
+    val mComponentName: Any? =
+        runCatching {
+            com.sevtinge.hyperceiler.libhook.base.BaseHook.getObjectField(obj, "mComponentName")
+        }.getOrElse {
+            com.sevtinge.hyperceiler.libhook.base.BaseHook.getObjectField(obj, "componentName")
+        }
 
     fun componentNames(type: Int, str: String): ComponentName {
         return when (type) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/StateFlowHelper.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/StateFlowHelper.kt
@@ -63,16 +63,36 @@ object StateFlowHelper {
         stateFlow ?: return
 
         when (stateFlow::class.java.simpleName) {
-            "ReadonlyStateFlow" -> {
-                if (isMoreAndroidVersion(36)) {
-                    stateFlow.getFirstFieldByExactType(MUTABLE_STATE_FLOW)
-                } else {
-                    stateFlow.getFirstFieldByExactType(STATE_FLOW)
-                }
-            }
+            "ReadonlyStateFlow" -> resolveDelegateFlow(stateFlow)
             "StateFlowImpl" -> stateFlow
             else -> null
         }?.callMethod("setValue", value)
+    }
+
+    /**
+     * Returns the mutable flow that a ReadonlyStateFlow delegates to.
+     *
+     * getFirstFieldByExactType matches a field's *declared* type, and ReadonlyStateFlow
+     * has exactly one field, $$delegate_0:
+     *  - on Android 16 it is declared as MutableStateFlow;
+     *  - the kotlinx.coroutines bundled with HyperOS 3.3 (Android 17) declares it as
+     *    StateFlow again (the constructor parameter is still MutableStateFlow, so
+     *    newReadonlyStateFlow is unaffected), and matching MutableStateFlow exactly then
+     *    throws MemberNotFoundException.
+     *
+     * The instance actually stored in the field is always a StateFlowImpl, so setValue
+     * works either way. The old lookup is attempted first so older versions keep hitting
+     * exactly the same branch as before.
+     */
+    private fun resolveDelegateFlow(stateFlow: Any): Any? {
+        if (isMoreAndroidVersion(36)) {
+            runCatching {
+                stateFlow.getFirstFieldByExactType(MUTABLE_STATE_FLOW)
+            }.getOrNull()?.let { return it }
+        }
+        return runCatching {
+            stateFlow.getFirstFieldByExactType(STATE_FLOW)
+        }.getOrNull()
     }
 
     @JvmStatic

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/StateFlowHelper.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/StateFlowHelper.kt
@@ -69,21 +69,19 @@ object StateFlowHelper {
         }?.callMethod("setValue", value)
     }
 
-    /**
-     * Returns the mutable flow that a ReadonlyStateFlow delegates to.
-     *
-     * getFirstFieldByExactType matches a field's *declared* type, and ReadonlyStateFlow
-     * has exactly one field, $$delegate_0:
-     *  - on Android 16 it is declared as MutableStateFlow;
-     *  - the kotlinx.coroutines bundled with HyperOS 3.3 (Android 17) declares it as
-     *    StateFlow again (the constructor parameter is still MutableStateFlow, so
-     *    newReadonlyStateFlow is unaffected), and matching MutableStateFlow exactly then
-     *    throws MemberNotFoundException.
-     *
-     * The instance actually stored in the field is always a StateFlowImpl, so setValue
-     * works either way. The old lookup is attempted first so older versions keep hitting
-     * exactly the same branch as before.
-     */
+    // Returns the mutable flow that a ReadonlyStateFlow delegates to.
+    //
+    // getFirstFieldByExactType matches a field's *declared* type, and ReadonlyStateFlow
+    // has exactly one field, $delegate_0:
+    //  - on Android 16 it is declared as MutableStateFlow;
+    //  - the kotlinx.coroutines bundled with HyperOS 3.3 (Android 17) declares it as
+    //    StateFlow again (the constructor parameter is still MutableStateFlow, so
+    //    newReadonlyStateFlow is unaffected), and matching MutableStateFlow exactly then
+    //    throws MemberNotFoundException.
+    //
+    // The instance actually stored in the field is always a StateFlowImpl, so setValue
+    // works either way. The old lookup is attempted first so older versions keep hitting
+    // exactly the same branch as before.
     private fun resolveDelegateFlow(stateFlow: Any): Any? {
         if (isMoreAndroidVersion(36)) {
             runCatching {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/systemui/JavaAdapter.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/systemui/JavaAdapter.kt
@@ -20,16 +20,55 @@ package com.sevtinge.hyperceiler.libhook.utils.hookapi.systemui
 
 import com.sevtinge.hyperceiler.libhook.base.BaseHook
 import io.github.lingqiqi5211.ezhooktool.core.callMethod
+import io.github.lingqiqi5211.ezhooktool.core.callStaticMethod
+import io.github.lingqiqi5211.ezhooktool.xposed.dsl.getObjectField
 import java.util.concurrent.CancellationException
 import java.util.function.Consumer
 
 class JavaAdapter(instance: Any) : BaseReflectObject(instance) {
-    fun <T> alwaysCollectFlow(flow: Any, consumer: Consumer<T>): KotlinJob {
-        val job = KotlinJob(instance.callMethod("alwaysCollectFlow", flow, consumer) as Any)
+    fun <T> alwaysCollectFlow(flow: Any, consumer: Consumer<T>): KotlinJob? {
+        val job = KotlinJob(startCollect(flow, consumer) ?: return null)
         // Flow collector 持有 Consumer，而 Consumer 往往捕获当前模块 generation。
         // 不在热重载前取消会让旧 classloader 持续接收状态更新。
         BaseHook.registerHotReloadCleanup { job.cancel() }
         return job
+    }
+
+    /**
+     * Starts collecting and returns a cancellable Job where possible.
+     *
+     * The instance method `alwaysCollectFlow(Flow, Consumer)` used to return a Job. On
+     * HyperOS 3.3 (Android 17) its return type became void -- the body just passes
+     * applicationScope to the static overload of the same name and discards the result --
+     * so the original `as Any` threw a NullPointerException and collection was never set
+     * up at all.
+     *
+     * Check the instance method's return type first: if it is not void, use it as before;
+     * if it is void, call that static overload directly with applicationScope so a
+     * StandaloneCoroutine is still available for hot-reload cancellation. Exactly one of
+     * the two paths may run, otherwise the same Flow would be collected twice.
+     */
+    private fun <T> startCollect(flow: Any, consumer: Consumer<T>): Any? {
+        // methods (not declaredMethods) so an inherited overload is still found
+        val instanceMethod = instance.javaClass.methods.firstOrNull {
+            it.name == "alwaysCollectFlow" && it.parameterCount == 2
+        }
+
+        if (instanceMethod != null && instanceMethod.returnType != Void.TYPE) {
+            return runCatching {
+                instance.callMethod("alwaysCollectFlow", flow, consumer)
+            }.getOrNull()
+        }
+
+        runCatching {
+            val scope = instance.getObjectField("applicationScope")
+            instance.javaClass.callStaticMethod("alwaysCollectFlow", scope, flow, consumer)
+        }.getOrNull()?.let { return it }
+
+        // If the static overload did not work either, fall back to the void instance
+        // method: collection is still established, there is just no Job to cancel.
+        runCatching { instance.callMethod("alwaysCollectFlow", flow, consumer) }
+        return null
     }
 }
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/systemui/JavaAdapter.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/systemui/JavaAdapter.kt
@@ -26,6 +26,16 @@ import java.util.concurrent.CancellationException
 import java.util.function.Consumer
 
 class JavaAdapter(instance: Any) : BaseReflectObject(instance) {
+    private companion object {
+        const val ALWAYS_COLLECT_FLOW = "alwaysCollectFlow"
+    }
+
+    /**
+     * Collects [flow] for as long as SystemUI lives, handing every value to [consumer].
+     *
+     * @return the collecting Job, or null when the platform gave no cancellable handle
+     *   back. A null result still means collection was established.
+     */
     fun <T> alwaysCollectFlow(flow: Any, consumer: Consumer<T>): KotlinJob? {
         val job = KotlinJob(startCollect(flow, consumer) ?: return null)
         // Flow collector 持有 Consumer，而 Consumer 往往捕获当前模块 generation。
@@ -34,40 +44,38 @@ class JavaAdapter(instance: Any) : BaseReflectObject(instance) {
         return job
     }
 
-    /**
-     * Starts collecting and returns a cancellable Job where possible.
-     *
-     * The instance method `alwaysCollectFlow(Flow, Consumer)` used to return a Job. On
-     * HyperOS 3.3 (Android 17) its return type became void -- the body just passes
-     * applicationScope to the static overload of the same name and discards the result --
-     * so the original `as Any` threw a NullPointerException and collection was never set
-     * up at all.
-     *
-     * Check the instance method's return type first: if it is not void, use it as before;
-     * if it is void, call that static overload directly with applicationScope so a
-     * StandaloneCoroutine is still available for hot-reload cancellation. Exactly one of
-     * the two paths may run, otherwise the same Flow would be collected twice.
-     */
+    // Starts collecting and returns a cancellable Job where possible.
+    //
+    // The instance method alwaysCollectFlow(Flow, Consumer) used to return a Job. On
+    // HyperOS 3.3 (Android 17) its return type became void -- the body just passes
+    // applicationScope to the static overload of the same name and discards the result --
+    // so the original `as Any` threw a NullPointerException and collection was never set
+    // up at all.
+    //
+    // Check the instance method's return type first: if it is not void, use it as before;
+    // if it is void, call that static overload directly with applicationScope so a
+    // StandaloneCoroutine is still available for hot-reload cancellation. Exactly one of
+    // the two paths may run, otherwise the same Flow would be collected twice.
     private fun <T> startCollect(flow: Any, consumer: Consumer<T>): Any? {
         // methods (not declaredMethods) so an inherited overload is still found
         val instanceMethod = instance.javaClass.methods.firstOrNull {
-            it.name == "alwaysCollectFlow" && it.parameterCount == 2
+            it.name == ALWAYS_COLLECT_FLOW && it.parameterCount == 2
         }
 
         if (instanceMethod != null && instanceMethod.returnType != Void.TYPE) {
             return runCatching {
-                instance.callMethod("alwaysCollectFlow", flow, consumer)
+                instance.callMethod(ALWAYS_COLLECT_FLOW, flow, consumer)
             }.getOrNull()
         }
 
         runCatching {
             val scope = instance.getObjectField("applicationScope")
-            instance.javaClass.callStaticMethod("alwaysCollectFlow", scope, flow, consumer)
+            instance.javaClass.callStaticMethod(ALWAYS_COLLECT_FLOW, scope, flow, consumer)
         }.getOrNull()?.let { return it }
 
         // If the static overload did not work either, fall back to the void instance
         // method: collection is still established, there is just no Job to cancel.
-        runCatching { instance.callMethod("alwaysCollectFlow", flow, consumer) }
+        runCatching { instance.callMethod(ALWAYS_COLLECT_FLOW, flow, consumer) }
         return null
     }
 }


### PR DESCRIPTION
## Problem

On HyperOS 3.3 / Android 17 (SDK 37) the module was unusable: the app exited on launch, and once the version gate was lifted a number of SystemUI features were broken or rendered twice.

Most of it traces back to one change: **HyperOS 3.3's SystemUI is built with R8 constructor inlining**, so several hooked classes have no `<init>` left in the dex — the constructor body is folded into its caller as `new-instance` + `iput`:

```
.method public final getMiuiOperatorConfig(I)L…$OperatorConfig;
    new-instance v13, L…$OperatorConfig;
    iput-boolean v6, v13, …->hideVolte:Z      ← no invoke-direct <init>
```

Constructor-based hooks therefore fail — loudly for explicit lookups, and **silently** for `hookAllConstructors`, which matches zero targets without logging anything. That silent case is what made the duplicated dual-row signal hard to spot.

## Approach

Each rule moves to an equivalent non-constructor entry point. Every new branch is selected by **runtime capability detection** (`declaredConstructors.isNotEmpty()`, field/method-name fallbacks, declared-type probes), always attempting the original path first, so behaviour on older releases is unchanged rather than gated on an SDK number.

## Fixed

**SystemUI**

| Rule | Cause | Fix |
|---|---|---|
| `HideVoWiFiIcon`, `MobileTypeSingle2Hook` | `OperatorConfig` ctor inlined into `getMiuiOperatorConfig`; `constructors[0]` threw `ArrayIndexOutOfBoundsException(length=0)` | hook that method's result |
| `MobilePublicHookV` | `MiuiCellularIconVM` has no ctor, so SIM 2's `isVisible` was never replaced and the dual row was drawn once per mobile view | handle in `MiuiMobileIconBinder#bind`; resolve `subId` via `subscriptionId` |
| `MobileTypeSingle2Hook` | same, plus `bind` passes a `MiuiMobileIconVMImpl` wrapper whose flows are cold `ChannelFlowTransformLatest` | unwrap to the inner VM |
| `StateFlowHelper` | `ReadonlyStateFlow.$$delegate_0` is declared `StateFlow` again, so the exact-type `MutableStateFlow` lookup missed | fall back to `StateFlow` |
| `JavaAdapter` | `alwaysCollectFlow(Flow, Consumer)` now returns `void`; casting to a non-null Job threw NPE and collection never started | use the static overload with `applicationScope` when the instance method is void |
| `StatusBarIcon` | block lists are `public static final` and reject reflective writes, aborting `init()` | lists are already mutated in place, so the write-back is no longer fatal |
| `PluginFactory` | `mComponentName` renamed to `componentName`; the throw was swallowed into `"Failed to create plugin context."`, silently disabling **every** `miui.systemui.plugin` feature | try both names; `NewPluginHelperKt` now logs the throwable |

**Launcher**

`WorkspacePadding` picked its class with `versionCode < 600000000 ? NEW : OLD`, inverted with respect to the `@Version(min = 600000000)` mapping used by the other home rules, so recent launchers resolved a class that no longer declares `getWorkspaceCellPadding*`. It now picks whichever class actually declares the getters instead of trusting a version code, and handles the `Init` → `init` rename.

## Graceful skips

These targets are simply absent from the ROM, so they now skip with a debug line instead of throwing:

- `RemoveSIMLockSuccessDialog` — `com.miui.simlock` is not in the global Security Center build
- `DisableThemeAdNew` — the built-in ad model was replaced by third-party SDKs
- `AllowThirdTheme`, `DisableUploadAppListNew` — DexKit anchor strings are gone; `optionalMember` skips a miss instead of throwing
- `VariousThirdApps` — `android.os.Build`'s final fields cannot be written reflectively on Android 17 (clearing `Field.accessFlags` does not help either, as finality is enforced below that mirror), so it reports an unsupported-platform warning rather than an error

Also adds Android 17 / HyperOS 3.3 to the supported version list as `SUPPORT_PARTIAL`.

## Behaviour changes worth reviewing

- `StateFlowHelper.resolveDelegateFlow` and `JavaAdapter.startCollect` return `null` on lookup failure instead of throwing, so callers no-op rather than aborting. `JavaAdapter.alwaysCollectFlow` is consequently `KotlinJob?`.
- `AllowThirdTheme` / `DisableUploadAppListNew` no longer surface `"Skip hook because initDexKit failed"`; the hook is skipped just as before, only quietly.

## Testing

Verified on a Xiaomi `nezha_eea` (2512BPNDAG), Android 17 / HyperOS `OS3.0.332.0.XPAEUXM`, SDK 37, LSPosed (KernelSU).

- module launches; VoLTE/VoWiFi hiding confirmed via `MiuiOperatorCustomizedPolicy` dumping `hideVolte=true, hideVowifi=true` for every slot
- dual-row signal renders once, with per-SIM levels cross-checked against `dumpsys telephony.registry` (`miuiLevel` → icon level) and confirmed to track each SIM independently
- launcher, Security Center, Theme Store, Camera, Settings, Gallery, Notes restarted and swept: **no** `Hook Failed`, `Class not found`, `Skip hook` or plugin-context errors remain
- `assembleDebug` passes

Not tested on OS 2.x / OS 3.0 hardware — the compatibility argument there rests on the old path being attempted first in every branch, which is worth a second pair of eyes.
