### PR TITLE
fix:修复"允许冻结受保护的应用"无法冻结应用商店（com.xiaomi.market）

### DIFF
--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/AllowDisableProtectedPackage.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/rules/systemframework/others/AllowDisableProtectedPackage.java
@@ -22,11 +22,14 @@ import androidx.annotation.NonNull;
 
 import com.sevtinge.hyperceiler.libhook.base.BaseHook;
 
+import io.github.lingqiqi5211.ezhooktool.xposed.common.HookParam;
+import io.github.lingqiqi5211.ezhooktool.xposed.java.IMethodHook;
 import io.github.libxposed.api.XposedInterface;
 
 public class AllowDisableProtectedPackage extends BaseHook {
     @Override
     public void init() {
+        // 旧版 MIUI (ProtectedPackages 拦截) —— 保留原有 hook
         findAndChainMethod("com.android.server.pm.ProtectedPackages", "isPackageStateProtected", new XposedInterface.Hooker() {
             @Override
             public Object intercept(@NonNull XposedInterface.Chain chain) throws Throwable {
@@ -39,5 +42,17 @@ public class AllowDisableProtectedPackage extends BaseHook {
                 return chain.proceed();
             }
         }, int.class, String.class);
+
+        // HyperOS (miui-services.jar) 冻结拦截本体
+        // shouldRestrictEnabledSettingsChange(String, int, int) -> void
+        // 命中即跳过原方法（setResult(null)），放行 pm disable / disable-user
+        findAndHookMethod("com.android.server.pm.PackageManagerServiceImpl",
+            "shouldRestrictEnabledSettingsChange", String.class, int.class, int.class,
+            new IMethodHook() {
+                @Override
+                public void before(HookParam param) {
+                    param.setResult(null);
+                }
+            });
     }
 }


### PR DESCRIPTION
原实现仅 hook AOSP 的 ProtectedPackages.isPackageStateProtected， HyperOS 已将冻结拦截迁移至 miui-services.jar 的
PackageManagerServiceImpl.shouldRestrictEnabledSettingsChange， 导致「允许冻结受保护的应用」在 HyperOS 上失效。

新增对该方法的 hook，命中即 setResult(null) 短路原方法，
放行 pm disable / disable-user（含 MIUI_CORE_APPS 名单包）。 方法/类不存在时静默跳过，兼容旧版 MIUI。

以上为DeepSeek V4撰写，实测在我的设备K90PM_3.0.308可以正常冻结应用商店