### PR TITLE
perf: optimize hook startup and worker lifecycle

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -44,11 +44,22 @@ jobs:
     runs-on: macos-latest
     name: Build App
     steps:
+      - name: Checkout trusted base for dependency warmup
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+
       - name: Checkout Git Repository
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - name: Setup JDK
         uses: actions/setup-java@v5
@@ -60,6 +71,23 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-overwrite-existing: true
+
+      - name: Warm dependency cache from trusted base
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_TOKEN: ${{ github.token }}
+        run: ./gradlew assembleDebug
+
+      - name: Checkout pull request merge commit
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
 
       - name: Create Sign File
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
@@ -83,11 +111,8 @@ jobs:
       - name: Build with Gradle (Debug)
         if: github.event_name == 'pull_request'
         shell: bash
-        env:
-          GIT_ACTOR: ${{ github.actor }}
-          GIT_TOKEN: ${{ github.token }}
         run: |
-          ./gradlew assembleDebug
+          ./gradlew --offline assembleDebug
           echo "IS_DEBUG=true" >> $GITHUB_ENV
 
       - name: Find APKs

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -28,6 +28,9 @@ on:
 
 jobs:
   build_app:
+    permissions:
+      contents: read
+      packages: read
     if: |
       (
         startsWith(github.event.head_commit.message, 'app: update version ')
@@ -329,6 +332,7 @@ jobs:
   push_to_debug_group:
     if: |
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (
         startsWith(github.event.head_commit.message, 'app: update version ')
         ||

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Build with Gradle (Debug)
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_TOKEN: ${{ github.token }}
         run: |
           ./gradlew assembleDebug
           echo "IS_DEBUG=true" >> $GITHUB_ENV

--- a/app/src/main/java/com/sevtinge/hyperceiler/search/SearchHelper.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/search/SearchHelper.java
@@ -57,7 +57,7 @@ public class SearchHelper {
 
     public static void initIndex(Context context, boolean force) {
         AndroidLog.d(TAG, "initIndex: force = " + force);
-        ThreadPoolManager.getInstance().submit(() -> {
+        ThreadPoolManager.submit(() -> {
             ModDao dao = AppDatabase.getInstance(context).modDao();
             if (force || dao.getCount() == 0) {
                 rebuildIndex(context, dao);

--- a/app/src/main/java/com/sevtinge/hyperceiler/settings/development/DevelopmentKillFragment.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/settings/development/DevelopmentKillFragment.java
@@ -40,7 +40,6 @@ import com.sevtinge.hyperceiler.utils.PackagesUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 import fan.appcompat.app.AlertDialog;
 
@@ -70,11 +69,10 @@ public class DevelopmentKillFragment extends SettingsPreferenceFragment implemen
         mCheck = findPreference("prefs_key_development_kill_find_process");
         mKillPackage = findPreference("prefs_key_development_kill_package");
         mName = findPreference("prefs_key_development_kill_app_name");
-        ExecutorService executorService = ThreadPoolManager.getInstance();
         handler = new Handler(requireContext().getMainLooper());
         if (ensureInstalledAppsPermission()) {
             ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_data));
-            initApp(executorService);
+            initApp();
         }
         mCheck.setOnPreferenceClickListener(this);
         mName.setOnPreferenceClickListener(this);
@@ -192,19 +190,13 @@ public class DevelopmentKillFragment extends SettingsPreferenceFragment implemen
         return AppsTool.killApps(kill);
     }
 
-    private void initApp(ExecutorService executorService) {
-        executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                appData = PackagesUtils.getInstalledPackagesByFlag(0);
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        init = true;
-                        ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_done));
-                    }
-                });
-            }
+    private void initApp() {
+        ThreadPoolManager.submit(() -> {
+            appData = PackagesUtils.getInstalledPackagesByFlag(0);
+            handler.post(() -> {
+                init = true;
+                ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_done));
+            });
         });
     }
 
@@ -259,7 +251,7 @@ public class DevelopmentKillFragment extends SettingsPreferenceFragment implemen
         if (PermissionUtils.canReadInstalledApps(requireContext())
             || PermissionUtils.isInstalledAppsPermissionGranted(permissions, grantResults)) {
             ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_data));
-            initApp(ThreadPoolManager.getInstance());
+            initApp();
             return;
         }
 

--- a/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/VariousFragment.java
+++ b/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/VariousFragment.java
@@ -143,7 +143,7 @@ public class VariousFragment extends DashboardFragment {
     }
 
     private void restartClipboardInputMethods() {
-        ThreadPoolManager.getInstance().submit(() ->
+        ThreadPoolManager.submit(() ->
             AppsTool.killApps(
                 "com.sohu.inputmethod.sogou.xiaomi",
                 "com.sohu.inputmethod.sogou",

--- a/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/systemui/TileSettings.java
+++ b/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/systemui/TileSettings.java
@@ -111,7 +111,7 @@ public class TileSettings extends DashboardFragment implements Preference.OnPref
     }
 
     public void killTaplus() {
-        ThreadPoolManager.getInstance().submit(() -> handler.post(() ->
+        ThreadPoolManager.submit(() -> handler.post(() ->
                 AppsTool.killApps("com.miui.contentextension")));
     }
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/base/BaseLoad.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/base/BaseLoad.java
@@ -298,7 +298,7 @@ public abstract class BaseLoad {
 
         List<Future<DexKitInitResult>> futures = new ArrayList<>(pendingHooks.size());
         for (BaseHook hook : pendingHooks) {
-            futures.add(ThreadPoolManager.getInstance().submit(() -> runDexKitInit(hook)));
+            futures.add(ThreadPoolManager.submit(() -> runDexKitInit(hook)));
         }
 
         List<DexKitInitResult> results = new ArrayList<>(pendingHooks.size());

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
@@ -93,7 +93,7 @@ public class ContextUtils {
      * @author 焕晨HChen
      */
     public static void getWaitContext(IContext iContext, boolean isSystem) {
-        ThreadPoolManager.getInstance().submit(() -> {
+        ThreadPoolManager.submit(() -> {
             int flag = isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP;
             Context context = getContextNoError(flag);
             if (context == null) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
@@ -21,6 +21,7 @@ package com.sevtinge.hyperceiler.libhook.utils.api;
 import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
+import android.os.SystemClock;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -43,6 +44,8 @@ public class ContextUtils {
     }
 
     private static final String TAG = "HyperCeiler";
+    private static final long WAIT_CONTEXT_TIMEOUT_MS = 10_000L;
+    private static final long WAIT_CONTEXT_RETRY_INTERVAL_MS = 50L;
     // 尝试全部
     public static final int FLAG_ALL = 0;
     // 仅获取当前应用
@@ -91,22 +94,22 @@ public class ContextUtils {
      */
     public static void getWaitContext(IContext iContext, boolean isSystem) {
         ThreadPoolManager.getInstance().submit(() -> {
-            Context context = getContextNoError(isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP);
+            int flag = isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP;
+            Context context = getContextNoError(flag);
             if (context == null) {
-                long time = System.currentTimeMillis();
-                long timeout = 10000; // 10秒
-                while (true) {
-                    long nowTime = System.currentTimeMillis();
-                    context = getContextNoError(isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP);
-                    // AndroidLog.i(TAG, "getWaitContext: " + context);
-                    if (context != null || nowTime - time > timeout) {
+                long deadline = SystemClock.uptimeMillis() + WAIT_CONTEXT_TIMEOUT_MS;
+                while (context == null && SystemClock.uptimeMillis() < deadline) {
+                    try {
+                        Thread.sleep(WAIT_CONTEXT_RETRY_INTERVAL_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         break;
                     }
+                    context = getContextNoError(flag);
                 }
             }
             iContext.hadContext(context);
         });
-        ThreadPoolManager.shutdown();
     }
 
     public interface IContext {
@@ -149,7 +152,7 @@ public class ContextUtils {
         if (context == null) {
             Method getSystemUiContext = clz.getDeclaredMethod("getSystemUiContext");
             getSystemUiContext.setAccessible(true);
-            context = (Context) getSystemContext.invoke(o);
+            context = (Context) getSystemUiContext.invoke(o);
         }
         return context;
     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
@@ -30,8 +30,9 @@ import java.util.concurrent.TimeUnit;
 public class ThreadPoolManager {
     private static final int NUM_THREADS = 5;
     private static final long KEEP_ALIVE_SECONDS = 30L;
-    private static volatile ExecutorService executor;
+    private static ExecutorService executor;
 
+    /** Creates the shared worker pool and allows idle core threads to retire. */
     private static ExecutorService createExecutor() {
         ThreadPoolExecutor pool = new ThreadPoolExecutor(
             NUM_THREADS,
@@ -44,22 +45,21 @@ public class ThreadPoolManager {
         return pool;
     }
 
-    public static ExecutorService getInstance() {
+    /** Returns the current worker pool, recreating it after a completed shutdown. */
+    public static synchronized ExecutorService getInstance() {
         if (executor == null || executor.isShutdown()) {
-            synchronized (ThreadPoolManager.class) {
-                if (executor == null || executor.isShutdown()) {
-                    executor = createExecutor();
-                }
-            }
+            executor = createExecutor();
         }
         return executor;
     }
 
-    public static void execute(Runnable task) {
+    /** Submits a fire-and-forget task without racing a concurrent hot-reload shutdown. */
+    public static synchronized void execute(Runnable task) {
         getInstance().execute(task);
     }
 
-    public static Future<?> submit(Runnable task) {
+    /** Submits a task without racing a concurrent hot-reload shutdown. */
+    public static synchronized Future<?> submit(Runnable task) {
         return getInstance().submit(task);
     }
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
@@ -19,8 +19,9 @@
 package com.sevtinge.hyperceiler.libhook.utils.api;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -28,13 +29,26 @@ import java.util.concurrent.TimeUnit;
  */
 public class ThreadPoolManager {
     private static final int NUM_THREADS = 5;
+    private static final long KEEP_ALIVE_SECONDS = 30L;
     private static volatile ExecutorService executor;
+
+    private static ExecutorService createExecutor() {
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+            NUM_THREADS,
+            NUM_THREADS,
+            KEEP_ALIVE_SECONDS,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>()
+        );
+        pool.allowCoreThreadTimeOut(true);
+        return pool;
+    }
 
     public static ExecutorService getInstance() {
         if (executor == null || executor.isShutdown()) {
             synchronized (ThreadPoolManager.class) {
                 if (executor == null || executor.isShutdown()) {
-                    executor = Executors.newFixedThreadPool(NUM_THREADS);
+                    executor = createExecutor();
                 }
             }
         }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
@@ -265,9 +265,19 @@ internal object DexKitCacheManager {
         if (!cacheDir.exists()) cacheDir.mkdirs()
         val cacheFile = File(cacheDir, DEXKIT_CACHE_FILE)
 
-        val pkgVersionName = AppsTool.getPackageVersionName(target)
-        val pkgVersionCode = AppsTool.getPackageVersionCode(target)
-        val hasPkgVersion = pkgVersionName.isNotEmpty() && pkgVersionCode != -1
+        // Resolve PackageInfo once. The previous path performed two separate PackageManager lookups
+        // and narrowed longVersionCode to Int, which could disable version-based invalidation for
+        // packages whose version code exceeds Int.MAX_VALUE.
+        val packageInfo = runCatching {
+            AppsTool.findContext(AppsTool.FlAG_ONLY_ANDROID)
+                ?.packageManager
+                ?.getPackageInfo(target.packageName, 0)
+        }.onFailure {
+            XposedLog.w(tag, "Failed to resolve package version for ${target.packageName}", it)
+        }.getOrNull()
+        val pkgVersionName = packageInfo?.versionName.orEmpty()
+        val pkgVersionCode = packageInfo?.longVersionCode ?: -1L
+        val hasPkgVersion = pkgVersionName.isNotEmpty() && pkgVersionCode != -1L
         val pkgVersion = if (hasPkgVersion) "$pkgVersionName($pkgVersionCode)" else null
 
         val isSystemUI = "com.android.systemui" == target.packageName

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,8 @@
 
 data class GprCredentials(val user: String, val key: String)
 
-fun loadGprCredentials(): GprCredentials {
-    // 优先从环境变量读取
+fun loadGprCredentials(): GprCredentials? {
+    // Prefer environment variables when available.
     val envUser = System.getenv("GIT_ACTOR")?.takeIf { it.isNotBlank() }
     val envKey = System.getenv("GIT_TOKEN")?.takeIf { it.isNotBlank() }
 
@@ -11,14 +11,10 @@ fun loadGprCredentials(): GprCredentials {
         return GprCredentials(envUser, envKey)
     }
 
-    // 从 signing.properties 读取
+    // Fall back to signing.properties for local/release builds.
     val propsFile = File(rootDir, "signing.properties")
     if (!propsFile.exists()) {
-        throw GradleException(
-            "Missing GitHub credentials. Please either:\n" +
-            "  1. Set GIT_ACTOR and GIT_TOKEN environment variables, or\n" +
-            "  2. Create 'signing.properties' with 'gpr.user' and 'gpr.key'"
-        )
+        return null
     }
 
     val props = java.util.Properties().apply {
@@ -35,7 +31,17 @@ fun loadGprCredentials(): GprCredentials {
     return GprCredentials(user, key)
 }
 
-val gprCredentials by lazy { loadGprCredentials() }
+val gprCredentials by lazy {
+    val credentials = loadGprCredentials()
+    if (credentials == null && !gradle.startParameter.isOffline) {
+        throw GradleException(
+            "Missing GitHub credentials. Please either:\n" +
+                "  1. Set GIT_ACTOR and GIT_TOKEN environment variables, or\n" +
+                "  2. Create 'signing.properties' with 'gpr.user' and 'gpr.key'"
+        )
+    }
+    credentials
+}
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
@@ -55,8 +61,8 @@ dependencyResolutionManagement {
         mavenLocal()
         maven("https://maven.pkg.github.com/ReChronoRain/HyperCeiler") {
             credentials {
-                username = gprCredentials.user
-                password = gprCredentials.key
+                username = gprCredentials?.user ?: "offline"
+                password = gprCredentials?.key ?: "offline"
             }
         }
         maven("https://jitpack.io")


### PR DESCRIPTION
## Summary

This is a focused runtime performance, lifecycle, and fork-CI hardening pass for shared hook initialization infrastructure.

### Changes

- Avoid busy-spinning in `ContextUtils.getWaitContext()` when the application context is not ready yet.
  - use monotonic uptime for the timeout
  - retry at a short interval instead of repeatedly reflecting in a tight loop
  - preserve thread interruption
- Keep the shared worker pool alive for initialization work, while allowing idle core threads to retire after 30 seconds.
- Serialize worker submissions with shutdown/hot-reload cleanup so tasks cannot race a closing executor and fail with `RejectedExecutionException`.
- Route current shared-pool call sites through the managed submission path instead of retaining raw executor instances.
- Fix the `getSystemUiContext()` fallback to invoke the method that was actually resolved instead of calling `getSystemContext()` a second time.
- Resolve target package metadata once when creating the DexKit cache and retain the full 64-bit `longVersionCode`.
  - removes duplicate PackageManager lookups during cache setup
  - avoids losing version-based cache invalidation when a package version code exceeds `Int.MAX_VALUE`
- Make fork PR validation safe and self-contained:
  - grant the build job only `contents: read` and `packages: read`
  - warm the Gradle dependency cache from the trusted base commit while the package token is available
  - check out the PR merge commit afterwards and build it with `--offline`, so PR-controlled Gradle code does not receive `github.token`
  - allow offline Gradle configuration without package credentials
  - skip the secret-dependent Telegram debug-upload job for fork PRs

## Expected impact

- Lower CPU pressure during very early process startup when `ActivityThread.currentApplication()` is temporarily unavailable.
- Less executor churn and lower idle thread/stack RAM in long-lived hooked processes.
- No submission-vs-shutdown race during hot reload or concurrent initialization.
- Slightly cheaper and more robust DexKit cache initialization.
- External/fork PRs can reach a real Gradle build without exposing package credentials to PR-controlled build logic.

## Scope

No feature fingerprints or hook targets are changed. Runtime changes are limited to shared startup, worker lifecycle, context resolution, and DexKit cache metadata handling. CI changes are limited to least-privilege package access, trusted dependency warmup, offline PR validation, and secret-dependent notification gating.