### PR TITLE
perf: harden startup, worker lifecycle and DexKit cache

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -44,11 +44,22 @@ jobs:
     runs-on: macos-latest
     name: Build App
     steps:
+      - name: Checkout trusted base for dependency warmup
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
+
       - name: Checkout Git Repository
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
 
       - name: Setup JDK
         uses: actions/setup-java@v5
@@ -60,6 +71,23 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-overwrite-existing: true
+
+      - name: Warm dependency cache from trusted base
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_TOKEN: ${{ github.token }}
+        run: ./gradlew assembleDebug
+
+      - name: Checkout pull request merge commit
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+          submodules: true
+          persist-credentials: false
 
       - name: Create Sign File
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
@@ -83,11 +111,8 @@ jobs:
       - name: Build with Gradle (Debug)
         if: github.event_name == 'pull_request'
         shell: bash
-        env:
-          GIT_ACTOR: ${{ github.actor }}
-          GIT_TOKEN: ${{ github.token }}
         run: |
-          ./gradlew assembleDebug
+          ./gradlew --offline assembleDebug
           echo "IS_DEBUG=true" >> $GITHUB_ENV
 
       - name: Find APKs

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -28,6 +28,9 @@ on:
 
 jobs:
   build_app:
+    permissions:
+      contents: read
+      packages: read
     if: |
       (
         startsWith(github.event.head_commit.message, 'app: update version ')
@@ -329,6 +332,7 @@ jobs:
   push_to_debug_group:
     if: |
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (
         startsWith(github.event.head_commit.message, 'app: update version ')
         ||

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Build with Gradle (Debug)
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_TOKEN: ${{ github.token }}
         run: |
           ./gradlew assembleDebug
           echo "IS_DEBUG=true" >> $GITHUB_ENV

--- a/app/src/main/java/com/sevtinge/hyperceiler/search/SearchHelper.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/search/SearchHelper.java
@@ -57,7 +57,7 @@ public class SearchHelper {
 
     public static void initIndex(Context context, boolean force) {
         AndroidLog.d(TAG, "initIndex: force = " + force);
-        ThreadPoolManager.getInstance().submit(() -> {
+        ThreadPoolManager.submit(() -> {
             ModDao dao = AppDatabase.getInstance(context).modDao();
             if (force || dao.getCount() == 0) {
                 rebuildIndex(context, dao);

--- a/app/src/main/java/com/sevtinge/hyperceiler/settings/development/DevelopmentKillFragment.java
+++ b/app/src/main/java/com/sevtinge/hyperceiler/settings/development/DevelopmentKillFragment.java
@@ -40,7 +40,6 @@ import com.sevtinge.hyperceiler.utils.PackagesUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 import fan.appcompat.app.AlertDialog;
 
@@ -70,11 +69,10 @@ public class DevelopmentKillFragment extends SettingsPreferenceFragment implemen
         mCheck = findPreference("prefs_key_development_kill_find_process");
         mKillPackage = findPreference("prefs_key_development_kill_package");
         mName = findPreference("prefs_key_development_kill_app_name");
-        ExecutorService executorService = ThreadPoolManager.getInstance();
         handler = new Handler(requireContext().getMainLooper());
         if (ensureInstalledAppsPermission()) {
             ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_data));
-            initApp(executorService);
+            initApp();
         }
         mCheck.setOnPreferenceClickListener(this);
         mName.setOnPreferenceClickListener(this);
@@ -192,19 +190,13 @@ public class DevelopmentKillFragment extends SettingsPreferenceFragment implemen
         return AppsTool.killApps(kill);
     }
 
-    private void initApp(ExecutorService executorService) {
-        executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                appData = PackagesUtils.getInstalledPackagesByFlag(0);
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        init = true;
-                        ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_done));
-                    }
-                });
-            }
+    private void initApp() {
+        ThreadPoolManager.submit(() -> {
+            appData = PackagesUtils.getInstalledPackagesByFlag(0);
+            handler.post(() -> {
+                init = true;
+                ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_done));
+            });
         });
     }
 
@@ -259,7 +251,7 @@ public class DevelopmentKillFragment extends SettingsPreferenceFragment implemen
         if (PermissionUtils.canReadInstalledApps(requireContext())
             || PermissionUtils.isInstalledAppsPermissionGranted(permissions, grantResults)) {
             ToastHelper.makeText(ContextUtils.getContext(ContextUtils.FLAG_CURRENT_APP), getString(R.string.development_kill_loading_data));
-            initApp(ThreadPoolManager.getInstance());
+            initApp();
             return;
         }
 

--- a/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/VariousFragment.java
+++ b/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/VariousFragment.java
@@ -143,7 +143,7 @@ public class VariousFragment extends DashboardFragment {
     }
 
     private void restartClipboardInputMethods() {
-        ThreadPoolManager.getInstance().submit(() ->
+        ThreadPoolManager.submit(() ->
             AppsTool.killApps(
                 "com.sohu.inputmethod.sogou.xiaomi",
                 "com.sohu.inputmethod.sogou",

--- a/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/systemui/TileSettings.java
+++ b/library/core/src/main/java/com/sevtinge/hyperceiler/hooker/systemui/TileSettings.java
@@ -111,7 +111,7 @@ public class TileSettings extends DashboardFragment implements Preference.OnPref
     }
 
     public void killTaplus() {
-        ThreadPoolManager.getInstance().submit(() -> handler.post(() ->
+        ThreadPoolManager.submit(() -> handler.post(() ->
                 AppsTool.killApps("com.miui.contentextension")));
     }
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/base/BaseLoad.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/base/BaseLoad.java
@@ -298,7 +298,7 @@ public abstract class BaseLoad {
 
         List<Future<DexKitInitResult>> futures = new ArrayList<>(pendingHooks.size());
         for (BaseHook hook : pendingHooks) {
-            futures.add(ThreadPoolManager.getInstance().submit(() -> runDexKitInit(hook)));
+            futures.add(ThreadPoolManager.submit(() -> runDexKitInit(hook)));
         }
 
         List<DexKitInitResult> results = new ArrayList<>(pendingHooks.size());

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
@@ -93,7 +93,7 @@ public class ContextUtils {
      * @author 焕晨HChen
      */
     public static void getWaitContext(IContext iContext, boolean isSystem) {
-        ThreadPoolManager.getInstance().submit(() -> {
+        ThreadPoolManager.submit(() -> {
             int flag = isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP;
             Context context = getContextNoError(flag);
             if (context == null) {

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ContextUtils.java
@@ -21,6 +21,7 @@ package com.sevtinge.hyperceiler.libhook.utils.api;
 import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
+import android.os.SystemClock;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
@@ -43,6 +44,8 @@ public class ContextUtils {
     }
 
     private static final String TAG = "HyperCeiler";
+    private static final long WAIT_CONTEXT_TIMEOUT_MS = 10_000L;
+    private static final long WAIT_CONTEXT_RETRY_INTERVAL_MS = 50L;
     // 尝试全部
     public static final int FLAG_ALL = 0;
     // 仅获取当前应用
@@ -91,22 +94,22 @@ public class ContextUtils {
      */
     public static void getWaitContext(IContext iContext, boolean isSystem) {
         ThreadPoolManager.getInstance().submit(() -> {
-            Context context = getContextNoError(isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP);
+            int flag = isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP;
+            Context context = getContextNoError(flag);
             if (context == null) {
-                long time = System.currentTimeMillis();
-                long timeout = 10000; // 10秒
-                while (true) {
-                    long nowTime = System.currentTimeMillis();
-                    context = getContextNoError(isSystem ? FlAG_ONLY_ANDROID : FLAG_CURRENT_APP);
-                    // AndroidLog.i(TAG, "getWaitContext: " + context);
-                    if (context != null || nowTime - time > timeout) {
+                long deadline = SystemClock.uptimeMillis() + WAIT_CONTEXT_TIMEOUT_MS;
+                while (context == null && SystemClock.uptimeMillis() < deadline) {
+                    try {
+                        Thread.sleep(WAIT_CONTEXT_RETRY_INTERVAL_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         break;
                     }
+                    context = getContextNoError(flag);
                 }
             }
             iContext.hadContext(context);
         });
-        ThreadPoolManager.shutdown();
     }
 
     public interface IContext {
@@ -149,7 +152,7 @@ public class ContextUtils {
         if (context == null) {
             Method getSystemUiContext = clz.getDeclaredMethod("getSystemUiContext");
             getSystemUiContext.setAccessible(true);
-            context = (Context) getSystemContext.invoke(o);
+            context = (Context) getSystemUiContext.invoke(o);
         }
         return context;
     }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
@@ -30,8 +30,9 @@ import java.util.concurrent.TimeUnit;
 public class ThreadPoolManager {
     private static final int NUM_THREADS = 5;
     private static final long KEEP_ALIVE_SECONDS = 30L;
-    private static volatile ExecutorService executor;
+    private static ExecutorService executor;
 
+    /** Creates the shared worker pool and allows idle core threads to retire. */
     private static ExecutorService createExecutor() {
         ThreadPoolExecutor pool = new ThreadPoolExecutor(
             NUM_THREADS,
@@ -44,22 +45,21 @@ public class ThreadPoolManager {
         return pool;
     }
 
-    public static ExecutorService getInstance() {
+    /** Returns the current worker pool, recreating it after a completed shutdown. */
+    public static synchronized ExecutorService getInstance() {
         if (executor == null || executor.isShutdown()) {
-            synchronized (ThreadPoolManager.class) {
-                if (executor == null || executor.isShutdown()) {
-                    executor = createExecutor();
-                }
-            }
+            executor = createExecutor();
         }
         return executor;
     }
 
-    public static void execute(Runnable task) {
+    /** Submits a fire-and-forget task without racing a concurrent hot-reload shutdown. */
+    public static synchronized void execute(Runnable task) {
         getInstance().execute(task);
     }
 
-    public static Future<?> submit(Runnable task) {
+    /** Submits a task without racing a concurrent hot-reload shutdown. */
+    public static synchronized Future<?> submit(Runnable task) {
         return getInstance().submit(task);
     }
 

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/api/ThreadPoolManager.java
@@ -19,8 +19,9 @@
 package com.sevtinge.hyperceiler.libhook.utils.api;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -28,13 +29,26 @@ import java.util.concurrent.TimeUnit;
  */
 public class ThreadPoolManager {
     private static final int NUM_THREADS = 5;
+    private static final long KEEP_ALIVE_SECONDS = 30L;
     private static volatile ExecutorService executor;
+
+    private static ExecutorService createExecutor() {
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+            NUM_THREADS,
+            NUM_THREADS,
+            KEEP_ALIVE_SECONDS,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>()
+        );
+        pool.allowCoreThreadTimeOut(true);
+        return pool;
+    }
 
     public static ExecutorService getInstance() {
         if (executor == null || executor.isShutdown()) {
             synchronized (ThreadPoolManager.class) {
                 if (executor == null || executor.isShutdown()) {
-                    executor = Executors.newFixedThreadPool(NUM_THREADS);
+                    executor = createExecutor();
                 }
             }
         }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
@@ -52,6 +52,9 @@ import java.io.File
  * 缓存未命中时：通过 [RecyclableBridge.withBridge] 获取原生桥，执行用户查询，
  * 再把结果序列化后写回缓存。
  *
+ * 如果缓存 descriptor 已损坏或无法在当前 ClassLoader 中解析，会只淘汰对应 key，
+ * 并在同一次会话中回退到 DexKit 查询，而不是让整个 hook 初始化失败。
+ *
  * 线程安全约束：所有公开方法都可以跨线程调用。
  * DexKit 2.2.0 已支持同桥并发访问，框架层会在 Hook 初始化阶段自动并行调度。
  * 生命周期方法（[init] / [releaseBridge] / [clearAllCache]）使用内部锁保护状态。
@@ -135,10 +138,12 @@ internal object DexKitCacheManager {
         val currentTarget = target ?: throw IllegalStateException("DexKit not ready")
         val classLoader = currentTarget.classLoader
 
-        // 缓存 key 不带前缀，由 strings / lists 分组隐式区分
-        // 先尝试命中内存缓存，命中时不创建原生桥
+        // 缓存 key 不带前缀，由 strings / lists 分组隐式区分。
+        // 如果 descriptor 已失效，只淘汰当前 key 并继续走 miss 路径。
         cache?.getString(key, null)?.let { cached ->
-            return deserializeAndResolve(cached, classLoader) as T
+            resolveCachedEntry(key) {
+                deserializeAndResolve(cached, classLoader) as T
+            }?.let { return it }
         }
 
         // 缓存未命中，获取原生桥执行查询
@@ -164,10 +169,11 @@ internal object DexKitCacheManager {
         val currentTarget = target ?: throw IllegalStateException("DexKit not ready")
         val classLoader = currentTarget.classLoader
 
-        // 缓存 key 不带前缀，由 strings / lists 分组隐式区分
-        // 先尝试命中缓存
+        // 列表中任一 descriptor 无法解析时，整组淘汰并重新查询，避免返回部分旧结果。
         cache?.getStringList(key, null)?.let { cachedList ->
-            return cachedList.map { deserializeAndResolve(it, classLoader) as T }
+            resolveCachedEntry(key) {
+                cachedList.map { deserializeAndResolve(it, classLoader) as T }
+            }?.let { return it }
         }
 
         // 缓存未命中，获取原生桥执行查询
@@ -291,6 +297,21 @@ internal object DexKitCacheManager {
     }
 
     /**
+     * 尝试解析缓存项；若 descriptor 已损坏/过期则仅删除该 key，让调用方走正常 DexKit miss 路径。
+     * VM 级致命错误不吞掉。
+     */
+    private inline fun <T> resolveCachedEntry(key: String, resolver: () -> T): T? {
+        return try {
+            resolver()
+        } catch (t: Throwable) {
+            if (t is VirtualMachineError || t is ThreadDeath) throw t
+            XposedLog.w(tag, "DexKitCacheManager: stale cache entry '$key', resolving again", t)
+            cache?.remove(key)
+            null
+        }
+    }
+
+    /**
      * 把缓存里的序列化字符串还原成真实反射对象（Method / Field / Class）。
      *
      * [ISerializable.deserialize] 会根据描述符格式自动判断类型：
@@ -339,5 +360,4 @@ internal object DexKitCacheManager {
         }
         file.delete()
     }
-
 }

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
@@ -271,9 +271,19 @@ internal object DexKitCacheManager {
         if (!cacheDir.exists()) cacheDir.mkdirs()
         val cacheFile = File(cacheDir, DEXKIT_CACHE_FILE)
 
-        val pkgVersionName = AppsTool.getPackageVersionName(target)
-        val pkgVersionCode = AppsTool.getPackageVersionCode(target)
-        val hasPkgVersion = pkgVersionName.isNotEmpty() && pkgVersionCode != -1
+        // Resolve PackageInfo once. The previous path performed two separate PackageManager lookups
+        // and narrowed longVersionCode to Int, which could disable version-based invalidation for
+        // packages whose version code exceeds Int.MAX_VALUE.
+        val packageInfo = runCatching {
+            AppsTool.findContext(AppsTool.FlAG_ONLY_ANDROID)
+                ?.packageManager
+                ?.getPackageInfo(target.packageName, 0)
+        }.onFailure {
+            XposedLog.w(tag, "Failed to resolve package version for ${target.packageName}", it)
+        }.getOrNull()
+        val pkgVersionName = packageInfo?.versionName.orEmpty()
+        val pkgVersionCode = packageInfo?.longVersionCode ?: -1L
+        val hasPkgVersion = pkgVersionName.isNotEmpty() && pkgVersionCode != -1L
         val pkgVersion = if (hasPkgVersion) "$pkgVersionName($pkgVersionCode)" else null
 
         val isSystemUI = "com.android.systemui" == target.packageName

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/DexKitCacheManager.kt
@@ -265,9 +265,19 @@ internal object DexKitCacheManager {
         if (!cacheDir.exists()) cacheDir.mkdirs()
         val cacheFile = File(cacheDir, DEXKIT_CACHE_FILE)
 
-        val pkgVersionName = AppsTool.getPackageVersionName(target)
-        val pkgVersionCode = AppsTool.getPackageVersionCode(target)
-        val hasPkgVersion = pkgVersionName.isNotEmpty() && pkgVersionCode != -1
+        // Resolve PackageInfo once. The previous path performed two separate PackageManager lookups
+        // and narrowed longVersionCode to Int, which could disable version-based invalidation for
+        // packages whose version code exceeds Int.MAX_VALUE.
+        val packageInfo = runCatching {
+            AppsTool.findContext(AppsTool.FlAG_ONLY_ANDROID)
+                ?.packageManager
+                ?.getPackageInfo(target.packageName, 0)
+        }.onFailure {
+            XposedLog.w(tag, "Failed to resolve package version for ${target.packageName}", it)
+        }.getOrNull()
+        val pkgVersionName = packageInfo?.versionName.orEmpty()
+        val pkgVersionCode = packageInfo?.longVersionCode ?: -1L
+        val hasPkgVersion = pkgVersionName.isNotEmpty() && pkgVersionCode != -1L
         val pkgVersion = if (hasPkgVersion) "$pkgVersionName($pkgVersionCode)" else null
 
         val isSystemUI = "com.android.systemui" == target.packageName

--- a/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/JsonFileCache.kt
+++ b/library/libhook/src/main/java/com/sevtinge/hyperceiler/libhook/utils/hookapi/dexkit/JsonFileCache.kt
@@ -26,11 +26,12 @@ import org.luckypray.dexkit.annotations.DexKitExperimentalApi
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
-import java.nio.channels.FileLock
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.util.TreeMap
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * [DexKitCacheBridge.Cache] 的 JSON 文件实现。
@@ -38,6 +39,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  * 缓存数据保存在 JSON 文件中，并在构造阶段做版本校验。
  * 所有写入先进入建议队列，再由单消费者串行应用到内存映射表，
  * 最后在 [flush] 时统一落盘。
+ *
+ * 多进程宿主会共享同一个应用 dataDir，因此持久化时使用独立 lock 文件串行化写入，
+ * 在锁内重新读取最新磁盘状态并合并本进程增量，最后通过同目录临时文件原子替换。
+ * 这样可避免不同进程互相覆盖刚生成的 DexKit cache，也避免在拿到锁之前截断主缓存文件。
  *
  * 当前 JSON 格式示例：
  * ```json
@@ -86,12 +91,19 @@ internal class JsonFileCache(
         val listValue: List<String>? = null,
     )
 
+    private data class CacheState(
+        val strings: LinkedHashMap<String, String> = LinkedHashMap(),
+        val lists: LinkedHashMap<String, List<String>> = LinkedHashMap(),
+    )
+
     private val ioLock = Any()
     private val strings = LinkedHashMap<String, String>()
     private val lists = LinkedHashMap<String, List<String>>()
     private val writeSuggestions = ConcurrentLinkedQueue<WriteSuggestion>()
+    private val pendingDiskWrites = ArrayList<WriteSuggestion>()
 
-    private val dirty = AtomicBoolean(false)
+    /** 当前进程启动时读到旧版本/损坏文件时，确保 session 结束会修复磁盘文件。 */
+    private var rewriteRequired = false
 
     init {
         loadAndValidate()
@@ -155,19 +167,19 @@ internal class JsonFileCache(
         synchronized(ioLock) {
             while (true) {
                 val suggestionCount = applyWriteSuggestionsLocked()
-                if (suggestionCount == 0 && !dirty.get()) return
+                if (pendingDiskWrites.isEmpty() && !rewriteRequired) return
 
-                val stringsSnapshot = snapshotStringsLocked()
-                val listsSnapshot = snapshotListsLocked()
-                dirty.set(false)
-                if (!saveToDisk(stringsSnapshot, listsSnapshot)) {
-                    dirty.set(true)
-                    return
-                }
+                val writesSnapshot = ArrayList(pendingDiskWrites)
+                val savedState = saveToDisk(writesSnapshot) ?: return
+
+                replaceMemoryStateLocked(savedState)
+                pendingDiskWrites.clear()
+                rewriteRequired = false
+
                 if (suggestionCount > 0) {
                     XposedLog.d(tag, "JsonFileCache: applied $suggestionCount queued writes")
                 }
-                if (writeSuggestions.isEmpty() && !dirty.get()) return
+                if (writeSuggestions.isEmpty()) return
             }
         }
     }
@@ -180,169 +192,238 @@ internal class JsonFileCache(
             }
 
             try {
-                val text = cacheFile.readText(Charsets.UTF_8)
-                if (text.isBlank()) return
-
-                val root = JSONObject(text)
-                val fileVersion = root.optInt(KEY_VERSION, 0)
-                val filePkgVersion = root.takeIf { it.has(KEY_PKG_VERSION) }?.getString(KEY_PKG_VERSION)
-                val fileOsVersion = root.takeIf { it.has(KEY_OS_VERSION) }?.getString(KEY_OS_VERSION)
-
-                // 版本失效判断
-                var needClear = false
-
-                if (fileVersion != CACHE_VERSION) {
-                    XposedLog.d(tag, "JsonFileCache: version changed $fileVersion -> $CACHE_VERSION")
-                    needClear = true
-                }
-                if (pkgVersion != null && pkgVersion != filePkgVersion) {
-                    XposedLog.d(tag, "JsonFileCache: pkgVersion changed $filePkgVersion -> $pkgVersion")
-                    needClear = true
-                }
-                if (osVersion != null && osVersion != fileOsVersion) {
-                    XposedLog.d(tag, "JsonFileCache: osVersion changed $fileOsVersion -> $osVersion")
-                    needClear = true
-                }
-
-                if (needClear) {
-                    dirty.set(true)
+                val state = readValidatedState(cacheFile, logVersionChanges = true)
+                if (state == null) {
+                    rewriteRequired = true
                     return
                 }
 
-                // 读取单值缓存
-                root.optJSONObject(KEY_STRINGS)?.let { strObj ->
-                    for (k in strObj.keys()) {
-                        strings[k] = strObj.getString(k)
-                    }
-                }
-
-                // 读取列表缓存
-                root.optJSONObject(KEY_LISTS)?.let { listObj ->
-                    for (k in listObj.keys()) {
-                        val arr = listObj.getJSONArray(k)
-                        val list = ArrayList<String>(arr.length())
-                        for (i in 0 until arr.length()) {
-                            list.add(arr.getString(i))
-                        }
-                        lists[k] = list
-                    }
-                }
-
+                replaceMemoryStateLocked(state)
                 XposedLog.d(tag, "JsonFileCache: loaded ${strings.size} strings, ${lists.size} lists")
             } catch (t: Throwable) {
                 XposedLog.w(tag, "JsonFileCache: failed to load cache, starting fresh", t)
                 strings.clear()
                 lists.clear()
-                dirty.set(true)
+                rewriteRequired = true
             }
         }
     }
 
-    private fun saveToDisk(
-        stringsSnapshot: Map<String, String>,
-        listsSnapshot: Map<String, List<String>>,
-    ): Boolean {
+    /**
+     * 在跨进程 writer lock 内读取最新有效状态并应用本进程增量。
+     *
+     * 若当前进程启动时看到的是旧/损坏文件，但其它进程已经先修复了文件，
+     * 这里会复用那个最新有效状态，而不是再次把它清空。
+     */
+    private fun saveToDisk(writes: List<WriteSuggestion>): CacheState? {
         try {
             val dir = cacheFile.parentFile
             if (dir != null && !dir.exists()) {
                 if (!dir.mkdirs() && !dir.exists()) {
                     XposedLog.w(tag, "JsonFileCache: failed to create cache dir: ${dir.absolutePath}")
-                    return false
+                    return null
                 }
             }
-
-            val root = JSONObject()
-            root.put(KEY_VERSION, CACHE_VERSION)
-            if (pkgVersion != null) root.put(KEY_PKG_VERSION, pkgVersion)
-            if (osVersion != null) root.put(KEY_OS_VERSION, osVersion)
-
-            val strObj = JSONObject()
-            for ((k, v) in stringsSnapshot) {
-                strObj.put(k, v)
-            }
-            root.put(KEY_STRINGS, strObj)
-
-            val listObj = JSONObject()
-            for ((k, v) in listsSnapshot) {
-                val arr = JSONArray()
-                for (s in v) arr.put(s)
-                listObj.put(k, arr)
-            }
-            root.put(KEY_LISTS, listObj)
-
-            val json = root.toString(2)
-                // JSONObject.toString() 会把 / 转义为 \/，手动还原以提高可读性
-                .replace("\\/", "/")
-
-            if (!cacheFile.exists()) {
-                if (!cacheFile.createNewFile() && !cacheFile.exists()) {
-                    XposedLog.w(tag, "JsonFileCache: failed to create cache file")
-                    return false
-                }
+            if (dir == null) {
+                XposedLog.w(tag, "JsonFileCache: cache file has no parent directory")
+                return null
             }
 
+            val lockFile = File(dir, "${cacheFile.name}.lock")
             FileChannel.open(
-                cacheFile.toPath(),
+                lockFile.toPath(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE
+            ).use { lockChannel ->
+                val fileLock = lockChannel.lock()
+                try {
+                    val latestState = try {
+                        readValidatedState(cacheFile, logVersionChanges = false)
+                    } catch (t: Throwable) {
+                        XposedLog.w(tag, "JsonFileCache: failed to merge latest cache, rebuilding", t)
+                        null
+                    }
+                    val mergedState = latestState ?: CacheState()
+                    for (suggestion in writes) {
+                        applySuggestion(mergedState.strings, mergedState.lists, suggestion)
+                    }
+
+                    writeStateAtomically(dir, mergedState)
+                    XposedLog.d(
+                        tag,
+                        "JsonFileCache: saved ${mergedState.strings.size} strings, ${mergedState.lists.size} lists"
+                    )
+                    return mergedState
+                } finally {
+                    fileLock.release()
+                }
+            }
+        } catch (t: Throwable) {
+            XposedLog.w(tag, "JsonFileCache: failed to save cache", t)
+            return null
+        }
+    }
+
+    private fun writeStateAtomically(dir: File, state: CacheState) {
+        val json = serializeState(state)
+        val tempPath = Files.createTempFile(dir.toPath(), "${cacheFile.name}.", ".tmp")
+        try {
+            FileChannel.open(
+                tempPath,
                 StandardOpenOption.WRITE,
                 StandardOpenOption.TRUNCATE_EXISTING
             ).use { channel ->
-                var lock: FileLock? = null
-                try {
-                    lock = channel.lock()
-                    val bytes = json.toByteArray(Charsets.UTF_8)
-                    val buf = ByteBuffer.wrap(bytes)
-                    while (buf.hasRemaining()) {
-                        channel.write(buf)
-                    }
-                    channel.force(false)
-                } finally {
-                    lock?.release()
+                val bytes = json.toByteArray(Charsets.UTF_8)
+                val buf = ByteBuffer.wrap(bytes)
+                while (buf.hasRemaining()) {
+                    channel.write(buf)
                 }
+                channel.force(false)
             }
 
-            XposedLog.d(tag, "JsonFileCache: saved ${stringsSnapshot.size} strings, ${listsSnapshot.size} lists")
-            return true
-        } catch (t: Throwable) {
-            XposedLog.w(tag, "JsonFileCache: failed to save cache", t)
-            return false
+            try {
+                Files.move(
+                    tempPath,
+                    cacheFile.toPath(),
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING
+                )
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(
+                    tempPath,
+                    cacheFile.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING
+                )
+            }
+        } finally {
+            Files.deleteIfExists(tempPath)
         }
+    }
+
+    private fun readValidatedState(file: File, logVersionChanges: Boolean): CacheState? {
+        if (!file.exists()) return null
+
+        val text = file.readText(Charsets.UTF_8)
+        if (text.isBlank()) return null
+
+        val root = JSONObject(text)
+        val fileVersion = root.optInt(KEY_VERSION, 0)
+        val filePkgVersion = root.takeIf { it.has(KEY_PKG_VERSION) }?.getString(KEY_PKG_VERSION)
+        val fileOsVersion = root.takeIf { it.has(KEY_OS_VERSION) }?.getString(KEY_OS_VERSION)
+
+        var valid = true
+        if (fileVersion != CACHE_VERSION) {
+            if (logVersionChanges) {
+                XposedLog.d(tag, "JsonFileCache: version changed $fileVersion -> $CACHE_VERSION")
+            }
+            valid = false
+        }
+        if (pkgVersion != null && pkgVersion != filePkgVersion) {
+            if (logVersionChanges) {
+                XposedLog.d(tag, "JsonFileCache: pkgVersion changed $filePkgVersion -> $pkgVersion")
+            }
+            valid = false
+        }
+        if (osVersion != null && osVersion != fileOsVersion) {
+            if (logVersionChanges) {
+                XposedLog.d(tag, "JsonFileCache: osVersion changed $fileOsVersion -> $osVersion")
+            }
+            valid = false
+        }
+        if (!valid) return null
+
+        val state = CacheState()
+        root.optJSONObject(KEY_STRINGS)?.let { strObj ->
+            for (k in strObj.keys()) {
+                state.strings[k] = strObj.getString(k)
+            }
+        }
+        root.optJSONObject(KEY_LISTS)?.let { listObj ->
+            for (k in listObj.keys()) {
+                val arr = listObj.getJSONArray(k)
+                val list = ArrayList<String>(arr.length())
+                for (i in 0 until arr.length()) {
+                    list.add(arr.getString(i))
+                }
+                state.lists[k] = list
+            }
+        }
+        return state
+    }
+
+    private fun serializeState(state: CacheState): String {
+        val root = JSONObject()
+        root.put(KEY_VERSION, CACHE_VERSION)
+        if (pkgVersion != null) root.put(KEY_PKG_VERSION, pkgVersion)
+        if (osVersion != null) root.put(KEY_OS_VERSION, osVersion)
+
+        val strObj = JSONObject()
+        for ((k, v) in TreeMap(state.strings)) {
+            strObj.put(k, v)
+        }
+        root.put(KEY_STRINGS, strObj)
+
+        val listObj = JSONObject()
+        for ((k, v) in TreeMap(state.lists)) {
+            val arr = JSONArray()
+            for (s in v) arr.put(s)
+            listObj.put(k, arr)
+        }
+        root.put(KEY_LISTS, listObj)
+
+        return root.toString(2)
+            // JSONObject.toString() 会把 / 转义为 \/，手动还原以提高可读性
+            .replace("\\/", "/")
     }
 
     private fun enqueueWriteSuggestion(suggestion: WriteSuggestion) {
         writeSuggestions.offer(suggestion)
-        dirty.set(true)
     }
 
     private fun applyWriteSuggestionsLocked(): Int {
         var count = 0
         while (true) {
             val suggestion = writeSuggestions.poll() ?: break
-            when (suggestion.type) {
-                WriteType.PUT_STRING -> {
-                    strings[suggestion.key!!] = suggestion.stringValue!!
-                }
-
-                WriteType.PUT_LIST -> {
-                    lists[suggestion.key!!] = suggestion.listValue!!
-                }
-
-                WriteType.REMOVE -> {
-                    val key = suggestion.key ?: continue
-                    strings.remove(key)
-                    lists.remove(key)
-                }
-
-                WriteType.CLEAR -> {
-                    strings.clear()
-                    lists.clear()
-                }
-            }
+            applySuggestion(strings, lists, suggestion)
+            pendingDiskWrites.add(suggestion)
             count++
         }
         return count
     }
 
-    private fun snapshotStringsLocked(): Map<String, String> = TreeMap(strings)
+    private fun applySuggestion(
+        stringMap: MutableMap<String, String>,
+        listMap: MutableMap<String, List<String>>,
+        suggestion: WriteSuggestion,
+    ) {
+        when (suggestion.type) {
+            WriteType.PUT_STRING -> {
+                stringMap[suggestion.key!!] = suggestion.stringValue!!
+            }
 
-    private fun snapshotListsLocked(): Map<String, List<String>> = TreeMap(lists)
+            WriteType.PUT_LIST -> {
+                listMap[suggestion.key!!] = ArrayList(suggestion.listValue!!)
+            }
+
+            WriteType.REMOVE -> {
+                val key = suggestion.key ?: return
+                stringMap.remove(key)
+                listMap.remove(key)
+            }
+
+            WriteType.CLEAR -> {
+                stringMap.clear()
+                listMap.clear()
+            }
+        }
+    }
+
+    private fun replaceMemoryStateLocked(state: CacheState) {
+        strings.clear()
+        strings.putAll(state.strings)
+        lists.clear()
+        for ((key, value) in state.lists) {
+            lists[key] = ArrayList(value)
+        }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,8 @@
 
 data class GprCredentials(val user: String, val key: String)
 
-fun loadGprCredentials(): GprCredentials {
-    // 优先从环境变量读取
+fun loadGprCredentials(): GprCredentials? {
+    // Prefer environment variables when available.
     val envUser = System.getenv("GIT_ACTOR")?.takeIf { it.isNotBlank() }
     val envKey = System.getenv("GIT_TOKEN")?.takeIf { it.isNotBlank() }
 
@@ -11,14 +11,10 @@ fun loadGprCredentials(): GprCredentials {
         return GprCredentials(envUser, envKey)
     }
 
-    // 从 signing.properties 读取
+    // Fall back to signing.properties for local/release builds.
     val propsFile = File(rootDir, "signing.properties")
     if (!propsFile.exists()) {
-        throw GradleException(
-            "Missing GitHub credentials. Please either:\n" +
-            "  1. Set GIT_ACTOR and GIT_TOKEN environment variables, or\n" +
-            "  2. Create 'signing.properties' with 'gpr.user' and 'gpr.key'"
-        )
+        return null
     }
 
     val props = java.util.Properties().apply {
@@ -35,7 +31,17 @@ fun loadGprCredentials(): GprCredentials {
     return GprCredentials(user, key)
 }
 
-val gprCredentials by lazy { loadGprCredentials() }
+val gprCredentials by lazy {
+    val credentials = loadGprCredentials()
+    if (credentials == null && !gradle.startParameter.isOffline) {
+        throw GradleException(
+            "Missing GitHub credentials. Please either:\n" +
+                "  1. Set GIT_ACTOR and GIT_TOKEN environment variables, or\n" +
+                "  2. Create 'signing.properties' with 'gpr.user' and 'gpr.key'"
+        )
+    }
+    credentials
+}
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
@@ -55,8 +61,8 @@ dependencyResolutionManagement {
         mavenLocal()
         maven("https://maven.pkg.github.com/ReChronoRain/HyperCeiler") {
             credentials {
-                username = gprCredentials.user
-                password = gprCredentials.key
+                username = gprCredentials?.user ?: "offline"
+                password = gprCredentials?.key ?: "offline"
             }
         }
         maven("https://jitpack.io")


### PR DESCRIPTION
## Summary

Consolidates the startup/lifecycle hardening work from #1687 with the DexKit cache process-safety fixes originally introduced in this PR.

### Startup and worker lifecycle

- Avoid busy-spinning in `ContextUtils.getWaitContext()` while the application context is not ready.
  - use monotonic uptime for the timeout
  - retry at a short interval instead of repeatedly reflecting in a tight loop
  - preserve thread interruption
- Keep the shared worker pool available during initialization while allowing idle core threads to retire after 30 seconds.
- Serialize managed worker submissions with shutdown/hot-reload cleanup so submissions cannot race a closing executor and fail with `RejectedExecutionException`.
- Route existing shared-pool call sites through the managed submission path instead of retaining raw executor instances.
- Fix the `getSystemUiContext()` fallback to invoke the method that was actually resolved.

### DexKit cache reliability and performance

- Serialize cross-process cache writers with a sidecar lock file.
- Re-read and merge the latest valid on-disk cache while holding the writer lock so one target process cannot overwrite entries learned by another.
- Write through a same-directory temporary file and atomically replace the cache, avoiding truncation before the writer lock is acquired.
- Preserve remove/clear operations as ordered deltas during cross-process merges.
- Evict only a cached descriptor that can no longer be resolved and retry that lookup through DexKit in the same session.
- Resolve target package metadata once during cache setup and retain the full 64-bit `longVersionCode`, avoiding duplicate PackageManager work and version-code narrowing.

### Fork CI hardening

- Grant the build job only `contents: read` and `packages: read`.
- Warm Gradle dependencies from the trusted base commit while package credentials are available.
- Check out the PR merge commit afterwards and run the PR-controlled build with `--offline`, so `github.token` is not exposed to PR-controlled Gradle logic.
- Allow offline Gradle configuration without package credentials.
- Skip the secret-dependent Telegram debug-upload job for fork PRs.

## Expected impact

- Lower CPU pressure during very early process startup.
- Less executor churn and lower idle thread/stack RAM in long-lived hooked processes.
- No submission-vs-shutdown race during hot reload/concurrent initialization.
- Fewer avoidable DexKit cache misses in multi-process apps and safer recovery from stale cached descriptors.
- Slightly cheaper and more robust cache initialization.
- Fork PRs can reach a real Gradle build without exposing repository/package credentials to PR-controlled build logic.

## Compatibility

- No feature fingerprints or hook targets are changed.
- The DexKit JSON schema/version remains unchanged (`CACHE_VERSION = 11`), so existing valid caches remain reusable.